### PR TITLE
관리자 활동로그 조회 화면 + CSV/Excel 다운로드

### DIFF
--- a/src/api/audit_log.ts
+++ b/src/api/audit_log.ts
@@ -1,0 +1,94 @@
+import { jsonFetchWithSession } from "../lib/fetch";
+import { API_ROOT } from "./root";
+
+export type AuditAction = "CREATE" | "UPDATE" | "DELETE" | "READ" | "EXPORT";
+export type AuditStatus = "SUCCESS" | "FAILURE" | "REVERTED";
+
+export interface AuditLogFilters {
+  from?: string;
+  to?: string;
+  action?: AuditAction;
+  status?: AuditStatus;
+  actor_id?: string;
+  patient_id?: string;
+  table_name?: string;
+}
+
+export interface AuditLogRow {
+  id: string;
+  table_name: string;
+  record_id: string | null;
+  action: AuditAction;
+  status: AuditStatus;
+  actor_id: string | null;
+  actor_name: string | null;
+  actor_role: string | null;
+  actor_hospital_id: string | null;
+  patient_id: string | null;
+  hospital_id: string | null;
+  ip_address: string | null;
+  user_agent: string | null;
+  changed_fields: string[];
+  error_message: string | null;
+  created_at: string;
+  actor: { email: string | null } | null;
+}
+
+export interface AuditLogPage {
+  page: number;
+  pageSize: number;
+  total: number;
+  rows: AuditLogRow[];
+}
+
+function toQuery(
+  filters: AuditLogFilters,
+  extra: Record<string, string | number> = {},
+): string {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries({ ...filters, ...extra })) {
+    if (value !== undefined && value !== "") params.set(key, String(value));
+  }
+  return params.toString();
+}
+
+export function getAuditLogs(
+  filters: AuditLogFilters,
+  page: number,
+  pageSize: number,
+): Promise<AuditLogPage> {
+  const query = toQuery(filters, { page, pageSize });
+  return jsonFetchWithSession<AuditLogPage>(
+    API_ROOT + "/audit_log?" + query,
+  );
+}
+
+// Downloads the filtered audit logs via the backend export endpoint. Using the
+// server endpoint (instead of building the file client-side) ensures the export
+// itself is recorded as an audit_log EXPORT action.
+export async function downloadAuditLogExport(
+  filters: AuditLogFilters,
+  format: "csv" | "xlsx",
+): Promise<void> {
+  const session_key = localStorage.getItem("session_key");
+  const query = toQuery(filters, { format });
+  const result = await fetch(API_ROOT + "/audit_log/export?" + query, {
+    headers: { Authorization: `Bearer ${session_key}` },
+  });
+  if (!result.ok) {
+    throw new Error(`Export failed (${result.status})`);
+  }
+
+  const blob = await result.blob();
+  const disposition = result.headers.get("Content-Disposition") ?? "";
+  const match = disposition.match(/filename="?([^"]+)"?/);
+  const stamp = new Date().toISOString().slice(0, 10);
+  const filename = match?.[1] ?? `audit_log_${stamp}.${format}`;
+
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/src/api/audit_log.ts
+++ b/src/api/audit_log.ts
@@ -7,6 +7,7 @@ export type AuditStatus = "SUCCESS" | "FAILURE" | "REVERTED";
 export interface AuditLogFilters {
   from?: string;
   to?: string;
+  hospital_id?: string;
   action?: AuditAction;
   status?: AuditStatus;
   actor_id?: string;

--- a/src/routes/admin.tsx
+++ b/src/routes/admin.tsx
@@ -15,13 +15,46 @@ import downloadIcon from "../assets/download.svg";
 import { getMeasurementsByHospital } from "../api/measurement";
 import ExcelJS from "exceljs";
 import { getEthnicityList, getInstrumentList } from "../api/static";
+import AdminAuditLog from "./admin_audit_log";
 
 const Table = styled.table`
-  text-align: center;
-  height: fit-content;
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+  & th,
   & td {
-    padding: 8px;
+    padding: 10px 12px;
+    text-align: center;
+    white-space: nowrap;
   }
+  & thead th {
+    background: #f3f4f6;
+    color: #374151;
+    font-weight: 600;
+    border-bottom: 1px solid #e5e7eb;
+  }
+  & tbody tr:nth-child(even) {
+    background: #fafafa;
+  }
+  & tbody tr:hover {
+    background: #f0f9ff;
+  }
+  & tbody td {
+    border-bottom: 1px solid #f0f0f0;
+    color: #374151;
+  }
+`;
+
+const Card = styled.div`
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  padding: 20px;
+`;
+
+const SectionTitle = styled.h2`
+  margin: 0 0 16px 0;
 `;
 
 export default function Admin() {
@@ -74,14 +107,14 @@ export default function Admin() {
         style={{
           display: "flex",
           width: "80%",
-          flexGrow: 1,
-          height: 0,
+          gap: "24px",
           justifyContent: "space-between",
+          alignItems: "flex-start",
         }}
       >
         <HospitalList onSelect={setSelectedHospitalId} />
-        <div>
-          <h2>Member List</h2>
+        <Card style={{ flex: 1 }}>
+          <SectionTitle>Member List</SectionTitle>
           <Table>
             <thead>
               <tr>
@@ -153,7 +186,10 @@ export default function Admin() {
               ))}
             </tbody>
           </Table>
-        </div>
+        </Card>
+      </div>
+      <div style={{ width: "80%", marginTop: "32px" }}>
+        <AdminAuditLog />
       </div>
     </TopDiv>
   );
@@ -164,12 +200,15 @@ const HospitalCardDiv = styled.div`
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-  padding: 8px;
-  border: 1px solid black;
+  padding: 12px 14px;
+  border: 1px solid #e5e7eb;
   cursor: pointer;
-  border-radius: 8px;
+  border-radius: 10px;
+  margin-bottom: 8px;
+  transition: background 0.15s, border-color 0.15s;
   &:hover {
-    background-color: lightgray;
+    background-color: #f0f9ff;
+    border-color: #bae6fd;
   }
 `;
 
@@ -311,12 +350,13 @@ function HospitalList({ onSelect }: { onSelect: (hospitalId: any) => void }) {
     return <div>Error: {query.error.message}</div>;
   }
   return (
-    <div>
-      <h2>Hospital List</h2>
+    <Card style={{ minWidth: "320px" }}>
+      <SectionTitle>Hospital List</SectionTitle>
       <SearchInput
         placeholder="Search hospital by name or code"
         value={search}
         onChange={(e) => setSearch(e.target.value)}
+        style={{ marginBottom: "12px", width: "100%" }}
       />
       <div>
         {filteredData.map((hospital: any) => (
@@ -327,6 +367,6 @@ function HospitalList({ onSelect }: { onSelect: (hospitalId: any) => void }) {
           />
         ))}
       </div>
-    </div>
+    </Card>
   );
 }

--- a/src/routes/admin_audit_log.tsx
+++ b/src/routes/admin_audit_log.tsx
@@ -10,6 +10,7 @@ import {
 } from "../api/audit_log";
 import { PrimaryButton, OutlinedButton } from "../components/button";
 import { TextInput } from "../components/input";
+import { getHospitalList } from "../api/hospital";
 
 const PAGE_SIZE = 50;
 
@@ -158,6 +159,18 @@ export default function AdminAuditLog() {
     placeholderData: keepPreviousData,
   });
 
+  const hospitalQuery = useQuery({
+    queryKey: ["hospital"],
+    queryFn: getHospitalList,
+    staleTime: Infinity,
+  });
+  const hospitalNameById = new Map<string, string>(
+    (hospitalQuery.data ?? []).map((h: any) => [
+      h.id,
+      `${h.name} (${h.code})`,
+    ]),
+  );
+
   const updateDraft = (patch: Partial<AuditLogFilters>) =>
     setDraft((prev) => ({ ...prev, ...patch }));
 
@@ -187,6 +200,23 @@ export default function AdminAuditLog() {
 
       <Card>
         <FilterRow>
+          <Field>
+            Hospital
+            <TextInput
+              as="select"
+              value={draft.hospital_id ?? ""}
+              onChange={(e) =>
+                updateDraft({ hospital_id: e.target.value || undefined })
+              }
+            >
+              <option value="">All hospitals</option>
+              {hospitalQuery.data?.map((h: any) => (
+                <option key={h.id} value={h.id}>
+                  {h.name} ({h.code})
+                </option>
+              ))}
+            </TextInput>
+          </Field>
           <Field>
             From
             <TextInput
@@ -262,6 +292,7 @@ export default function AdminAuditLog() {
             <thead>
               <tr>
                 <th>Time</th>
+                <th>Hospital</th>
                 <th>Actor</th>
                 <th>Role</th>
                 <th>Action</th>
@@ -276,6 +307,11 @@ export default function AdminAuditLog() {
               {query.data?.rows.map((r) => (
                 <tr key={r.id}>
                   <td>{formatTime(r.created_at)}</td>
+                  <td>
+                    {r.hospital_id
+                      ? hospitalNameById.get(r.hospital_id) ?? r.hospital_id
+                      : "-"}
+                  </td>
                   <td>{r.actor_name ?? r.actor?.email ?? "-"}</td>
                   <td>{r.actor_role ?? "-"}</td>
                   <td>
@@ -302,12 +338,12 @@ export default function AdminAuditLog() {
               ))}
               {query.isError && (
                 <tr>
-                  <Empty colSpan={9}>Error loading logs.</Empty>
+                  <Empty colSpan={10}>Error loading logs.</Empty>
                 </tr>
               )}
               {query.data && query.data.rows.length === 0 && (
                 <tr>
-                  <Empty colSpan={9}>No logs found.</Empty>
+                  <Empty colSpan={10}>No logs found.</Empty>
                 </tr>
               )}
             </tbody>

--- a/src/routes/admin_audit_log.tsx
+++ b/src/routes/admin_audit_log.tsx
@@ -1,0 +1,337 @@
+import { useState } from "react";
+import { useQuery, keepPreviousData } from "@tanstack/react-query";
+import styled from "styled-components";
+import {
+  getAuditLogs,
+  downloadAuditLogExport,
+  AuditLogFilters,
+  AuditAction,
+  AuditStatus,
+} from "../api/audit_log";
+import { PrimaryButton, OutlinedButton } from "../components/button";
+import { TextInput } from "../components/input";
+
+const PAGE_SIZE = 50;
+
+const ACTIONS: AuditAction[] = ["CREATE", "UPDATE", "DELETE", "READ", "EXPORT"];
+const STATUSES: AuditStatus[] = ["SUCCESS", "FAILURE", "REVERTED"];
+
+const ACTION_COLORS: Record<AuditAction, string> = {
+  CREATE: "#16a34a",
+  UPDATE: "#d97706",
+  DELETE: "#dc2626",
+  READ: "#64748b",
+  EXPORT: "#7c3aed",
+};
+
+const STATUS_COLORS: Record<AuditStatus, string> = {
+  SUCCESS: "#16a34a",
+  FAILURE: "#dc2626",
+  REVERTED: "#64748b",
+};
+
+const Section = styled.div`
+  width: 100%;
+`;
+
+const SectionTitle = styled.h2`
+  margin: 0 0 16px 0;
+`;
+
+const Card = styled.div`
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  overflow: hidden;
+`;
+
+const FilterRow = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: flex-end;
+  padding: 16px;
+  background: #f9fafb;
+  border-bottom: 1px solid #e5e7eb;
+`;
+
+const Field = styled.label`
+  display: flex;
+  flex-direction: column;
+  font-size: 12px;
+  font-weight: 600;
+  color: #6b7280;
+  gap: 4px;
+`;
+
+const Spacer = styled.div`
+  flex: 1;
+`;
+
+const TableScroll = styled.div`
+  overflow-x: auto;
+`;
+
+const LogTable = styled.table`
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+  & th,
+  & td {
+    padding: 10px 12px;
+    text-align: left;
+    white-space: nowrap;
+  }
+  & thead th {
+    background: #f3f4f6;
+    color: #374151;
+    font-weight: 600;
+    border-bottom: 1px solid #e5e7eb;
+    position: sticky;
+    top: 0;
+  }
+  & tbody tr:nth-child(even) {
+    background: #fafafa;
+  }
+  & tbody tr:hover {
+    background: #f0f9ff;
+  }
+  & tbody td {
+    border-bottom: 1px solid #f0f0f0;
+    color: #374151;
+  }
+`;
+
+const Badge = styled.span<{ $color: string }>`
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  color: ${(p) => p.$color};
+  background: ${(p) => p.$color}1a;
+`;
+
+const Mono = styled.span`
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  color: #6b7280;
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: inline-block;
+  vertical-align: bottom;
+`;
+
+const Pager = styled.div`
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 12px 16px;
+  border-top: 1px solid #e5e7eb;
+  font-size: 13px;
+  color: #6b7280;
+`;
+
+const Empty = styled.td`
+  text-align: center;
+  color: #9ca3af;
+  padding: 32px 12px;
+`;
+
+function formatTime(iso: string): string {
+  return new Date(iso).toLocaleString();
+}
+
+export default function AdminAuditLog() {
+  // Draft filters (the form) vs applied filters (what the query runs with).
+  const [draft, setDraft] = useState<AuditLogFilters>({});
+  const [applied, setApplied] = useState<AuditLogFilters>({});
+  const [page, setPage] = useState(1);
+  const [downloading, setDownloading] = useState(false);
+
+  const query = useQuery({
+    queryKey: ["audit_log", applied, page],
+    queryFn: () => getAuditLogs(applied, page, PAGE_SIZE),
+    placeholderData: keepPreviousData,
+  });
+
+  const updateDraft = (patch: Partial<AuditLogFilters>) =>
+    setDraft((prev) => ({ ...prev, ...patch }));
+
+  const applyFilters = () => {
+    setPage(1);
+    setApplied(draft);
+  };
+
+  const handleDownload = async (format: "csv" | "xlsx") => {
+    try {
+      setDownloading(true);
+      await downloadAuditLogExport(applied, format);
+    } catch (error) {
+      alert("Failed to download audit log");
+      console.error(error);
+    } finally {
+      setDownloading(false);
+    }
+  };
+
+  const total = query.data?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  return (
+    <Section>
+      <SectionTitle>Activity Log</SectionTitle>
+
+      <Card>
+        <FilterRow>
+          <Field>
+            From
+            <TextInput
+              type="date"
+              value={draft.from ?? ""}
+              onChange={(e) => updateDraft({ from: e.target.value })}
+            />
+          </Field>
+          <Field>
+            To
+            <TextInput
+              type="date"
+              value={draft.to ?? ""}
+              onChange={(e) => updateDraft({ to: e.target.value })}
+            />
+          </Field>
+          <Field>
+            Action
+            <TextInput
+              as="select"
+              value={draft.action ?? ""}
+              onChange={(e) =>
+                updateDraft({
+                  action: (e.target.value || undefined) as AuditAction,
+                })
+              }
+            >
+              <option value="">All</option>
+              {ACTIONS.map((a) => (
+                <option key={a} value={a}>
+                  {a}
+                </option>
+              ))}
+            </TextInput>
+          </Field>
+          <Field>
+            Status
+            <TextInput
+              as="select"
+              value={draft.status ?? ""}
+              onChange={(e) =>
+                updateDraft({
+                  status: (e.target.value || undefined) as AuditStatus,
+                })
+              }
+            >
+              <option value="">All</option>
+              {STATUSES.map((s) => (
+                <option key={s} value={s}>
+                  {s}
+                </option>
+              ))}
+            </TextInput>
+          </Field>
+          <PrimaryButton onClick={applyFilters}>Search</PrimaryButton>
+          <Spacer />
+          <OutlinedButton
+            disabled={downloading}
+            onClick={() => handleDownload("csv")}
+          >
+            Download CSV
+          </OutlinedButton>
+          <OutlinedButton
+            disabled={downloading}
+            onClick={() => handleDownload("xlsx")}
+          >
+            Download Excel
+          </OutlinedButton>
+        </FilterRow>
+
+        <TableScroll>
+          <LogTable>
+            <thead>
+              <tr>
+                <th>Time</th>
+                <th>Actor</th>
+                <th>Role</th>
+                <th>Action</th>
+                <th>Status</th>
+                <th>Table</th>
+                <th>Patient</th>
+                <th>Changed fields</th>
+                <th>IP</th>
+              </tr>
+            </thead>
+            <tbody>
+              {query.data?.rows.map((r) => (
+                <tr key={r.id}>
+                  <td>{formatTime(r.created_at)}</td>
+                  <td>{r.actor_name ?? r.actor?.email ?? "-"}</td>
+                  <td>{r.actor_role ?? "-"}</td>
+                  <td>
+                    <Badge $color={ACTION_COLORS[r.action]}>{r.action}</Badge>
+                  </td>
+                  <td>
+                    <Badge $color={STATUS_COLORS[r.status]}>{r.status}</Badge>
+                  </td>
+                  <td>{r.table_name}</td>
+                  <td>
+                    {r.patient_id ? (
+                      <Mono title={r.patient_id}>{r.patient_id}</Mono>
+                    ) : (
+                      "-"
+                    )}
+                  </td>
+                  <td>{r.changed_fields.join(", ") || "-"}</td>
+                  <td>
+                    <Mono title={r.ip_address ?? ""}>
+                      {r.ip_address ?? "-"}
+                    </Mono>
+                  </td>
+                </tr>
+              ))}
+              {query.isError && (
+                <tr>
+                  <Empty colSpan={9}>Error loading logs.</Empty>
+                </tr>
+              )}
+              {query.data && query.data.rows.length === 0 && (
+                <tr>
+                  <Empty colSpan={9}>No logs found.</Empty>
+                </tr>
+              )}
+            </tbody>
+          </LogTable>
+        </TableScroll>
+
+        <Pager>
+          <OutlinedButton
+            disabled={page <= 1}
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+          >
+            Prev
+          </OutlinedButton>
+          <span>
+            {page} / {totalPages} · {total} total
+          </span>
+          <OutlinedButton
+            disabled={page >= totalPages}
+            onClick={() => setPage((p) => p + 1)}
+          >
+            Next
+          </OutlinedButton>
+        </Pager>
+      </Card>
+    </Section>
+  );
+}


### PR DESCRIPTION
## 개요
관리자 페이지(`/admin`)에 활동 로그(audit log) 조회 화면과 CSV/Excel 다운로드 기능을 추가합니다. 백엔드는 이미 라이브된 `GET /audit_log`, `GET /audit_log/export`를 사용합니다.

## 변경 사항
- `src/api/audit_log.ts` (신규): 활동 로그 목록 조회 + export 다운로드 API. 다운로드는 백엔드 export 엔드포인트를 사용해, 다운로드 행위 자체도 EXPORT 감사 로그로 기록됩니다.
- `src/routes/admin_audit_log.tsx` (신규): 활동 로그 화면. 기간/작업종류(Action)/상태(Status) 필터, 페이지네이션(50건), CSV·Excel 다운로드 버튼, 색상 뱃지 표.
- `src/routes/admin.tsx`: 활동 로그 섹션 연결 및 관리자 페이지 카드 스타일 정리(병원/멤버/활동로그 통일).

## 참고
- 현재 백엔드 `GET /audit_log`는 병원(기관) 관리자 권한(is_admin) + 본인 기관 범위로 동작합니다. "플랫폼 전체 관리자가 전 기관 로그 조회" 방향으로 확정될 경우, 백엔드 권한·범위 조정 후 이 화면에 기관 선택만 연결하면 됩니다(표·필터·다운로드 컴포넌트는 그대로 재사용).
