### PR TITLE
안축장 입력 검증: 범위 차단(15~35) + 임상 이상치 확인 팝업

### DIFF
--- a/src/routes/chart/MeasurementList.tsx
+++ b/src/routes/chart/MeasurementList.tsx
@@ -182,6 +182,17 @@ export function AxialLengthRegisterDialog({
       alert("Invalid value detected");
       return;
     }
+    // Hard validation: axial length is physically bounded to 15~35mm, matching
+    // the backend constraint. Out-of-bound values are blocked here with a clear
+    // message (clinically abnormal-but-possible values are handled separately as
+    // a "query" confirmation in the parent's onConfirm).
+    const outOfRange = [odValue, osValue].some(
+      (v) => v !== null && (v < 15 || v > 35),
+    );
+    if (outOfRange) {
+      alert("안축장은 15~35mm 범위로 입력해주세요.");
+      return;
+    }
     onConfirm({
       instrumentId,
       date,

--- a/src/routes/chart/index.tsx
+++ b/src/routes/chart/index.tsx
@@ -58,6 +58,59 @@ import {
 import { MagnifyingGlass } from "../../components/magnifying_glass";
 import { Treatment } from "../../types/treatment";
 
+// Clinical "query" thresholds for axial length entries. Values outside the
+// normal range, or changing too fast vs. the previous measurement, raise a
+// confirmation popup so the operator can double-check the entry.
+const AXIAL_QUERY = {
+  minNormal: 20.0, // mm
+  maxNormal: 30.0, // mm
+  decreaseMm: 0.3, // flag if it dropped this much vs. the previous record
+  increaseMmPerYear: 1.0, // flag if annualised increase reaches this
+};
+
+// Returns human-readable warnings for a new axial length entry, comparing it
+// against the patient's most recent prior measurement when available.
+function axialLengthQueryWarnings(
+  next: { od: number | null; os: number | null; date: string },
+  previous: Measurement | undefined,
+): string[] {
+  const warnings: string[] = [];
+  (["od", "os"] as const).forEach((eye) => {
+    const value = next[eye];
+    if (value == null) return;
+    const label = eye.toUpperCase();
+
+    if (value <= AXIAL_QUERY.minNormal || value >= AXIAL_QUERY.maxNormal) {
+      warnings.push(
+        `안축장 ${label} ${value}mm가 기준 범위(${AXIAL_QUERY.minNormal}~${AXIAL_QUERY.maxNormal}mm)를 벗어났습니다.`,
+      );
+    }
+
+    const prevValue = previous?.[eye];
+    if (previous == null || prevValue == null) return;
+
+    const decrease = prevValue - value;
+    if (decrease >= AXIAL_QUERY.decreaseMm) {
+      warnings.push(
+        `안축장 ${label}가 직전 측정(${previous.date.split("T")[0]}, ${prevValue}mm) 대비 ${decrease.toFixed(2)}mm 감소했습니다.`,
+      );
+    }
+
+    const years =
+      (new Date(next.date).getTime() - new Date(previous.date).getTime()) /
+      (365.25 * 24 * 60 * 60 * 1000);
+    if (years > 0) {
+      const rate = (value - prevValue) / years;
+      if (rate >= AXIAL_QUERY.increaseMmPerYear) {
+        warnings.push(
+          `안축장 ${label} 증가 속도가 ${rate.toFixed(2)}mm/year로 기준(${AXIAL_QUERY.increaseMmPerYear}mm/year)을 초과했습니다.`,
+        );
+      }
+    }
+  });
+  return warnings;
+}
+
 export default function ChartRoute() {
   const { patientId } = useParams<{ patientId: string }>();
   const [searchParams] = useSearchParams();
@@ -542,6 +595,22 @@ export default function ChartRoute() {
           if (new Date(date) > new Date()) {
             alert("Can't register future measurement");
             return;
+          }
+          const previous = sortedAxialLength
+            .filter(
+              (m) => m.id !== editTargetId && new Date(m.date) < new Date(date),
+            )
+            .sort(
+              (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+            )[0];
+          const warnings = axialLengthQueryWarnings({ od, os, date }, previous);
+          if (warnings.length > 0) {
+            const proceed = confirm(
+              "다음 항목을 확인해주세요.\n\n" +
+                warnings.join("\n") +
+                "\n\n이대로 저장하시겠습니까?",
+            );
+            if (!proceed) return;
           }
           editTargetId
             ? updateMeasurementMutation.mutate({


### PR DESCRIPTION
## 개요
안축장 측정 입력에 두 단계 검증을 추가합니다.

## 변경 사항
### 1. 하드 검증 — 입력 범위 차단 (`MeasurementList.tsx`)
- 안축장 OD/OS가 **15~35mm 범위를 벗어나면** 저장을 막고 안내 메시지를 표시합니다. (백엔드 제약과 동일, 물리적으로 불가능한 값/오타 방지)

### 2. 임상 이상치 "쿼리" 확인 팝업 (`chart/index.tsx`)
물리적으로는 가능하지만 임상적으로 확인이 필요한 값에 대해, 저장 전 확인 팝업을 띄웁니다(확인 시 저장, 취소 시 수정 가능). 직전 측정값과 비교합니다.
- 안축장 입력값이 **20.0mm 이하 또는 30.0mm 이상**
- 안축장이 **직전 측정 대비 0.30mm 이상 감소** (아트로핀 사용 등)
- 안축장 **증가 속도가 1.0mm/year 이상**

## 비고
- 기준값은 임상 확정 시 교체 예정(상수로 분리되어 있음).
- "연구 등록 환자 한정" 및 지정자 메일 통지는 연구 등록 기능과 연동하여 별도로 적용 예정입니다(본 PR은 입력 시 팝업까지).
- 기존 측정 범위 검증 PR을 본 PR로 통합합니다.
