### PR TITLE
연구설정 탭: 알림 수신자(지정자) 등록

### DIFF
--- a/src/api/alert_recipient.ts
+++ b/src/api/alert_recipient.ts
@@ -1,0 +1,30 @@
+import { jsonFetchWithSession } from "../lib/fetch";
+import { API_ROOT } from "./root";
+
+export interface AlertRecipient {
+  id: string;
+  hospital_id: string;
+  email: string;
+  created_at: string;
+}
+
+export function getAlertRecipients(): Promise<AlertRecipient[]> {
+  return jsonFetchWithSession<AlertRecipient[]>(API_ROOT + "/alert_recipient");
+}
+
+export function addAlertRecipient(email: string): Promise<AlertRecipient> {
+  return jsonFetchWithSession<AlertRecipient>(
+    API_ROOT + "/alert_recipient",
+    { method: "POST" },
+    { email },
+  );
+}
+
+export function deleteAlertRecipient(id: string): Promise<void> {
+  return jsonFetchWithSession(
+    API_ROOT + "/alert_recipient/" + id,
+    { method: "DELETE" },
+    undefined,
+    false,
+  );
+}

--- a/src/routes/profile.tsx
+++ b/src/routes/profile.tsx
@@ -26,6 +26,11 @@ import {
   getHospitalList,
   getMembers,
 } from "../api/hospital";
+import {
+  getAlertRecipients,
+  addAlertRecipient,
+  deleteAlertRecipient,
+} from "../api/alert_recipient";
 import styled from "styled-components";
 import { Edit, DeleteOutline } from "@mui/icons-material";
 import {
@@ -1210,26 +1215,156 @@ function HospitalAdminProfile() {
     },
   });
 
+  const [tab, setTab] = useState<"members" | "study">("members");
+
   return (
     <ProfileSettingsDiv>
       <h2>Hospital Admin Settings</h2>
-      <h3>Member list</h3>
-      <Reactive
-        desktop={
-          <MemberListTable
-            members={memberListQuery.data ?? []}
-            onEdit={(userId, data) => editMutation.mutate({ userId, data })}
-            onDelete={(userId) => deleteMutation.mutate(userId)}
+      <div>
+        <TabBar>
+          <TabButton
+            $active={tab === "members"}
+            onClick={() => setTab("members")}
+          >
+            Member list
+          </TabButton>
+          <TabButton $active={tab === "study"} onClick={() => setTab("study")}>
+            연구설정
+          </TabButton>
+        </TabBar>
+
+        {tab === "members" ? (
+          <Reactive
+            desktop={
+              <MemberListTable
+                members={memberListQuery.data ?? []}
+                onEdit={(userId, data) => editMutation.mutate({ userId, data })}
+                onDelete={(userId) => deleteMutation.mutate(userId)}
+              />
+            }
+            mobile={
+              <MemberListCards
+                members={memberListQuery.data ?? []}
+                onEdit={(userId, data) => editMutation.mutate({ userId, data })}
+                onDelete={(userId) => deleteMutation.mutate(userId)}
+              />
+            }
           />
-        }
-        mobile={
-          <MemberListCards
-            members={memberListQuery.data ?? []}
-            onEdit={(userId, data) => editMutation.mutate({ userId, data })}
-            onDelete={(userId) => deleteMutation.mutate(userId)}
-          />
-        }
-      />
+        ) : (
+          <StudyAlertSettings />
+        )}
+      </div>
     </ProfileSettingsDiv>
+  );
+}
+
+const TabBar = styled.div`
+  display: flex;
+  gap: 4px;
+  border-bottom: 1px solid #e5e7eb;
+  margin-bottom: 16px;
+`;
+
+const TabButton = styled.button<{ $active: boolean }>`
+  background: none;
+  border: none;
+  padding: 10px 16px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  color: ${(p) => (p.$active ? "#16a34a" : "#6b7280")};
+  border-bottom: 2px solid
+    ${(p) => (p.$active ? "#16a34a" : "transparent")};
+  margin-bottom: -1px;
+`;
+
+const RecipientRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 12px;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  margin-bottom: 8px;
+`;
+
+function StudyAlertSettings() {
+  const queryClient = useQueryClient();
+  const [email, setEmail] = useState("");
+
+  const recipientQuery = useQuery({
+    queryKey: ["alert_recipient"],
+    queryFn: getAlertRecipients,
+  });
+
+  const invalidate = () =>
+    queryClient.invalidateQueries({ queryKey: ["alert_recipient"] });
+
+  const addMutation = useMutation({
+    mutationFn: addAlertRecipient,
+    onSuccess: () => {
+      setEmail("");
+      invalidate();
+    },
+    onError: (e: any) => {
+      alert(
+        e?.code === 409
+          ? "이미 등록된 이메일입니다."
+          : "이메일을 등록하지 못했습니다. 형식을 확인해주세요.",
+      );
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: deleteAlertRecipient,
+    onSuccess: invalidate,
+  });
+
+  const handleAdd = () => {
+    const trimmed = email.trim();
+    if (!trimmed) return;
+    addMutation.mutate(trimmed);
+  };
+
+  return (
+    <div style={{ marginTop: "24px" }}>
+      <h3>연구설정 — 알림 수신자</h3>
+      <p style={{ fontSize: "13px", color: "#6b7280", margin: "0 0 12px 0" }}>
+        연구 등록 환자에서 이상 값이 입력될 때 query 알림을 받을 이메일을
+        등록합니다.
+      </p>
+
+      <div style={{ display: "flex", gap: "8px", marginBottom: "16px" }}>
+        <TextInput
+          type="email"
+          placeholder="이메일 주소"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && handleAdd()}
+          style={{ flex: 1 }}
+        />
+        <PrimaryButton onClick={handleAdd} disabled={addMutation.isPending}>
+          추가
+        </PrimaryButton>
+      </div>
+
+      {recipientQuery.data && recipientQuery.data.length === 0 && (
+        <p style={{ fontSize: "13px", color: "#9ca3af" }}>
+          등록된 수신자가 없습니다.
+        </p>
+      )}
+      {recipientQuery.data?.map((r) => (
+        <RecipientRow key={r.id}>
+          <span>{r.email}</span>
+          <DangerButton
+            onClick={() => deleteMutation.mutate(r.id)}
+            style={{ padding: "4px 12px", fontSize: "13px" }}
+          >
+            삭제
+          </DangerButton>
+        </RecipientRow>
+      ))}
+    </div>
   );
 }


### PR DESCRIPTION
## 개요
사용자설정 페이지의 병원 관리자 화면에 "연구설정" 탭을 추가하고, query 알림 수신자(지정자) 이메일을 등록/삭제할 수 있게 합니다.

## 변경 사항
- `src/api/alert_recipient.ts` (신규): 수신자 목록/추가/삭제 API.
- `src/routes/profile.tsx`: HospitalAdminProfile에 탭(Member list / 연구설정) 추가. 연구설정 탭에서 수신 이메일 등록·삭제(중복/형식 오류 안내).

## 비고
- 백엔드 `jin0008/myopiaBackend` PR(alert_recipient)과 함께 동작합니다.
- 실제 발송 연결 및 "연구 등록 환자 한정"은 연구 등록 기능과 함께 추후 적용 예정입니다.
