### PR TITLE
안축장 증가속도 팝업 오탐 방지(최소 간격·최소 증가량)

### DIFF
--- a/src/routes/chart/index.tsx
+++ b/src/routes/chart/index.tsx
@@ -66,6 +66,8 @@ const AXIAL_QUERY = {
   maxNormal: 30.0, // mm
   decreaseMm: 0.3, // flag if it dropped this much vs. the previous record
   increaseMmPerYear: 1.0, // flag if annualised increase reaches this
+  minIntervalYears: 0.25, // only evaluate rate when measurements are ≥3mo apart
+  minIncreaseMm: 0.1, // and the raw increase exceeds measurement noise
 };
 
 // Returns human-readable warnings for a new axial length entry, comparing it
@@ -96,11 +98,17 @@ function axialLengthQueryWarnings(
       );
     }
 
+    // Guard against false positives: require a minimum interval (so a few-days
+    // gap doesn't blow up the annualised rate) and a raw increase above noise.
     const years =
       (new Date(next.date).getTime() - new Date(previous.date).getTime()) /
       (365.25 * 24 * 60 * 60 * 1000);
-    if (years > 0) {
-      const rate = (value - prevValue) / years;
+    const increase = value - prevValue;
+    if (
+      years >= AXIAL_QUERY.minIntervalYears &&
+      increase >= AXIAL_QUERY.minIncreaseMm
+    ) {
+      const rate = increase / years;
       if (rate >= AXIAL_QUERY.increaseMmPerYear) {
         warnings.push(
           `안축장 ${label} 증가 속도가 ${rate.toFixed(2)}mm/year로 기준(${AXIAL_QUERY.increaseMmPerYear}mm/year)을 초과했습니다.`,

--- a/src/routes/chart/index.tsx
+++ b/src/routes/chart/index.tsx
@@ -91,7 +91,8 @@ function axialLengthQueryWarnings(
     const prevValue = previous?.[eye];
     if (previous == null || prevValue == null) return;
 
-    const decrease = prevValue - value;
+    // Round to 3 decimals to avoid float error (e.g. 24.15 - 24.05 = 0.0999…).
+    const decrease = Math.round((prevValue - value) * 1000) / 1000;
     if (decrease >= AXIAL_QUERY.decreaseMm) {
       warnings.push(
         `안축장 ${label}가 직전 측정(${previous.date.split("T")[0]}, ${prevValue}mm) 대비 ${decrease.toFixed(2)}mm 감소했습니다.`,
@@ -103,7 +104,7 @@ function axialLengthQueryWarnings(
     const years =
       (new Date(next.date).getTime() - new Date(previous.date).getTime()) /
       (365.25 * 24 * 60 * 60 * 1000);
-    const increase = value - prevValue;
+    const increase = Math.round((value - prevValue) * 1000) / 1000;
     if (
       years >= AXIAL_QUERY.minIntervalYears &&
       increase >= AXIAL_QUERY.minIncreaseMm


### PR DESCRIPTION
## 개요
안축장 입력 팝업의 "증가 속도" 판정에서, 측정 간격이 매우 짧을 때 연간 환산 속도가 과도하게 계산되어 발생하는 오탐(alert fatigue)을 방지합니다.

## 변경 사항 (`chart/index.tsx`)
- 증가 속도(rate) 판정 시 두 가지 가드 추가:
  - **최소 측정 간격**: 두 측정일 간격이 0.25년(약 3개월) 이상일 때만 속도 계산
  - **최소 증가량**: 실제 증가량(value - prev)이 0.1mm(측정 오차 수준) 이상일 때만 알림
- 예: 14일 간격 0.05mm 증가 → 기존엔 1.30mm/year로 오탐, 이제는 알림 안 뜸.

## 비고
- 백엔드 알림 메일에도 동일 가드 적용(myopiaBackend PR #8). 프론트 팝업/백엔드 메일 판정 기준을 동일하게 유지.
