### PR TITLE
feat: 연구(study) 등록·방문 데이터 입력 프론트

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ const ProfessionalProfile = lazy(
   () => import("./routes/axial_length_growth/healthcare_professional"),
 );
 const ChartRoute = lazy(() => import("./routes/chart/index"));
+const StudyVisit = lazy(() => import("./routes/study_visit/index"));
 const RegularProfile = lazy(
   () => import("./routes/axial_length_growth/regular_user"),
 );
@@ -89,6 +90,10 @@ const App = () => {
                   element={<PatientDeleteRequest />}
                 />
                 <Route path="/chart/:patientId" element={<ChartRoute />} />
+                <Route
+                  path="/study-visit/:enrollmentId"
+                  element={<StudyVisit />}
+                />
                 <Route path="/profile" element={<Profile />} />
                 <Route path="/admin" element={<Admin />} />
                 <Route path="/who_we_are" element={<WhoWeAre />} />

--- a/src/api/study.ts
+++ b/src/api/study.ts
@@ -42,6 +42,15 @@ export function updateStudy(
   );
 }
 
+export function deleteStudy(studyId: string) {
+  return jsonFetchWithSession(
+    API_ROOT + `/study/admin/${studyId}`,
+    { method: "DELETE" },
+    undefined,
+    false,
+  );
+}
+
 export function getStudyHospitals(studyId: string) {
   return jsonFetchWithSession<string[]>(
     API_ROOT + `/study/admin/${studyId}/hospital`,

--- a/src/api/study.ts
+++ b/src/api/study.ts
@@ -13,7 +13,7 @@ export interface Study {
 
 export interface StudyInput {
   name: string;
-  code?: string;
+  code: string;
   description?: string;
 }
 

--- a/src/api/study.ts
+++ b/src/api/study.ts
@@ -147,3 +147,15 @@ export function createVisit(enrollmentId: string, data: VisitInput) {
     data,
   );
 }
+
+export function updateVisit(
+  enrollmentId: string,
+  visitId: string,
+  data: VisitInput,
+) {
+  return jsonFetchWithSession(
+    API_ROOT + `/study/enrollment/${enrollmentId}/visit/${visitId}`,
+    { method: "PATCH" },
+    data,
+  );
+}

--- a/src/api/study.ts
+++ b/src/api/study.ts
@@ -168,3 +168,12 @@ export function updateVisit(
     data,
   );
 }
+
+export function deleteVisit(enrollmentId: string, visitId: string) {
+  return jsonFetchWithSession(
+    API_ROOT + `/study/enrollment/${enrollmentId}/visit/${visitId}`,
+    { method: "DELETE" },
+    undefined,
+    false,
+  );
+}

--- a/src/api/study.ts
+++ b/src/api/study.ts
@@ -1,0 +1,149 @@
+import { jsonFetchWithSession } from "../lib/fetch";
+import { API_ROOT } from "./root";
+
+export interface Study {
+  id: string;
+  name: string;
+  code: string | null;
+  description: string | null;
+  active: boolean;
+  created_at: string;
+  _count?: { study_hospital: number };
+}
+
+export interface StudyInput {
+  name: string;
+  code?: string;
+  description?: string;
+}
+
+/* ---- site-admin: study master + hospital assignment ---- */
+
+export function getStudies() {
+  return jsonFetchWithSession<Study[]>(API_ROOT + "/study/admin");
+}
+
+export function createStudy(data: StudyInput) {
+  return jsonFetchWithSession<Study>(
+    API_ROOT + "/study/admin",
+    { method: "POST" },
+    data,
+  );
+}
+
+export function updateStudy(
+  studyId: string,
+  data: Partial<StudyInput> & { active?: boolean },
+) {
+  return jsonFetchWithSession<Study>(
+    API_ROOT + `/study/admin/${studyId}`,
+    { method: "PATCH" },
+    data,
+  );
+}
+
+export function getStudyHospitals(studyId: string) {
+  return jsonFetchWithSession<string[]>(
+    API_ROOT + `/study/admin/${studyId}/hospital`,
+  );
+}
+
+export function setStudyHospitals(studyId: string, hospitalIds: string[]) {
+  return jsonFetchWithSession(
+    API_ROOT + `/study/admin/${studyId}/hospital`,
+    { method: "PUT" },
+    { hospital_ids: hospitalIds },
+    false,
+  );
+}
+
+/* ---- professional: available studies + enrollment ---- */
+
+export interface AvailableStudy {
+  id: string;
+  name: string;
+  code: string | null;
+  description: string | null;
+}
+
+export function getAvailableStudies() {
+  return jsonFetchWithSession<AvailableStudy[]>(API_ROOT + "/study/available");
+}
+
+export interface Enrollment {
+  id: string;
+  study_id: string;
+  patient_id: string;
+  enrolled_at: string;
+  status: string;
+  study: { id: string; name: string; code: string | null };
+}
+
+export function getEnrollments(patientId: string) {
+  return jsonFetchWithSession<Enrollment[]>(
+    API_ROOT + `/study/enrollment?patient_id=${encodeURIComponent(patientId)}`,
+  );
+}
+
+export function enrollPatient(studyId: string, patientId: string) {
+  return jsonFetchWithSession<Enrollment>(
+    API_ROOT + "/study/enrollment",
+    { method: "POST" },
+    { study_id: studyId, patient_id: patientId },
+  );
+}
+
+/* ---- study visit (data entry) ---- */
+
+export interface EnrollmentDetail {
+  id: string;
+  study: { id: string; name: string; code: string | null };
+  patient_id: string;
+  enrolled_at: string;
+  visits: any[];
+}
+
+export function getEnrollment(enrollmentId: string) {
+  return jsonFetchWithSession<EnrollmentDetail>(
+    API_ROOT + `/study/enrollment/${enrollmentId}`,
+  );
+}
+
+export interface VisitInput {
+  visit_date: string;
+  va_od?: number | null;
+  va_os?: number | null;
+  bcva_od?: number | null;
+  bcva_os?: number | null;
+  refraction_method?: "Auto" | "MR" | "CR" | null;
+  ref_od_sph?: number | null;
+  ref_od_cyl?: number | null;
+  ref_od_axis?: number | null;
+  ref_os_sph?: number | null;
+  ref_os_cyl?: number | null;
+  ref_os_axis?: number | null;
+  slitlamp_od_normal?: boolean | null;
+  slitlamp_od_finding?: string | null;
+  slitlamp_os_normal?: boolean | null;
+  slitlamp_os_finding?: string | null;
+  iop_od?: number | null;
+  iop_os?: number | null;
+  accom_od?: number | null;
+  accom_os?: number | null;
+  axial_length?: {
+    measurement_id?: string | null;
+    instrument_id?: string | null;
+    od?: number | null;
+    os?: number | null;
+  } | null;
+  concomitant_meds?: string | null;
+  adverse_event?: string | null;
+}
+
+export function createVisit(enrollmentId: string, data: VisitInput) {
+  return jsonFetchWithSession(
+    API_ROOT + `/study/enrollment/${enrollmentId}/visit`,
+    { method: "POST" },
+    data,
+  );
+}

--- a/src/api/study.ts
+++ b/src/api/study.ts
@@ -85,6 +85,7 @@ export interface Enrollment {
   patient_id: string;
   enrolled_at: string;
   status: string;
+  subject_number: string | null;
   study: { id: string; name: string; code: string | null };
 }
 
@@ -109,6 +110,7 @@ export interface EnrollmentDetail {
   study: { id: string; name: string; code: string | null };
   patient_id: string;
   enrolled_at: string;
+  subject_number: string | null;
   visits: any[];
 }
 

--- a/src/routes/admin.tsx
+++ b/src/routes/admin.tsx
@@ -385,6 +385,17 @@ function StudyManagement() {
   const [newName, setNewName] = useState("");
   const [newCode, setNewCode] = useState("");
 
+  // Inline edit of an existing study's name/code.
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editName, setEditName] = useState("");
+  const [editCode, setEditCode] = useState("");
+
+  const startEdit = (study: Study) => {
+    setEditingId(study.id);
+    setEditName(study.name);
+    setEditCode(study.code ?? "");
+  };
+
   const createMutation = useMutation({
     mutationFn: () =>
       createStudy({
@@ -405,6 +416,16 @@ function StudyManagement() {
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: ["study", "admin"] }),
     onError: () => alert("상태 변경 실패"),
+  });
+
+  const editMutation = useMutation({
+    mutationFn: (vars: { id: string; name: string; code: string }) =>
+      updateStudy(vars.id, { name: vars.name, code: vars.code }),
+    onSuccess: () => {
+      setEditingId(null);
+      queryClient.invalidateQueries({ queryKey: ["study", "admin"] });
+    },
+    onError: (e: any) => alert(e?.message ?? "수정 실패"),
   });
 
   const deleteMutation = useMutation({
@@ -428,45 +449,99 @@ function StudyManagement() {
               $selected={selectedStudyId === study.id}
               onClick={() => setSelectedStudyId(study.id)}
             >
-              <div
-                style={{
-                  display: "flex",
-                  justifyContent: "space-between",
-                  alignItems: "center",
-                  gap: 8,
-                }}
-              >
-                <b style={{ opacity: study.active ? 1 : 0.5 }}>{study.name}</b>
-                <div style={{ display: "flex", gap: 6 }}>
-                  <PrimaryNagativeButton
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      toggleActiveMutation.mutate(study);
-                    }}
-                  >
-                    {study.active ? "비활성화" : "활성화"}
-                  </PrimaryNagativeButton>
-                  <PrimaryNagativeButton
-                    style={{ background: "#dc2626" }}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      if (
-                        confirm(
-                          `"${study.name}" 연구를 삭제할까요?\n등록된 환자·방문 데이터가 모두 함께 삭제되며 되돌릴 수 없습니다.`,
-                        )
-                      )
-                        deleteMutation.mutate(study.id);
-                    }}
-                  >
-                    삭제
-                  </PrimaryNagativeButton>
+              {editingId === study.id ? (
+                <div
+                  style={{ display: "flex", flexDirection: "column", gap: 6 }}
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <TextInput
+                    placeholder="연구명"
+                    value={editName}
+                    onChange={(e) => setEditName(e.target.value)}
+                  />
+                  <TextInput
+                    placeholder="코드 (필수, 예: LPTAT) — 연구번호 접두어"
+                    value={editCode}
+                    onChange={(e) => setEditCode(e.target.value)}
+                  />
+                  <div style={{ display: "flex", gap: 6 }}>
+                    <PrimaryButton
+                      onClick={() => {
+                        if (!editName.trim() || !editCode.trim()) {
+                          alert("연구명과 코드를 모두 입력해주세요.");
+                          return;
+                        }
+                        editMutation.mutate({
+                          id: study.id,
+                          name: editName.trim(),
+                          code: editCode.trim(),
+                        });
+                      }}
+                    >
+                      저장
+                    </PrimaryButton>
+                    <PrimaryNagativeButton onClick={() => setEditingId(null)}>
+                      취소
+                    </PrimaryNagativeButton>
+                  </div>
+                  <small style={{ color: "#9ca3af" }}>
+                    ※ 코드를 바꿔도 이미 부여된 기존 연구번호는 변경되지 않고,
+                    이후 등록되는 환자부터 새 코드가 적용됩니다.
+                  </small>
                 </div>
-              </div>
-              <small style={{ color: "#6b7280" }}>
-                {study.code ? `code: ${study.code} · ` : ""}
-                참여병원 {study._count?.study_hospital ?? 0}곳
-                {study.active ? "" : " · (비활성)"}
-              </small>
+              ) : (
+                <>
+                  <div
+                    style={{
+                      display: "flex",
+                      justifyContent: "space-between",
+                      alignItems: "center",
+                      gap: 8,
+                    }}
+                  >
+                    <b style={{ opacity: study.active ? 1 : 0.5 }}>
+                      {study.name}
+                    </b>
+                    <div style={{ display: "flex", gap: 6 }}>
+                      <PrimaryNagativeButton
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          startEdit(study);
+                        }}
+                      >
+                        수정
+                      </PrimaryNagativeButton>
+                      <PrimaryNagativeButton
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          toggleActiveMutation.mutate(study);
+                        }}
+                      >
+                        {study.active ? "비활성화" : "활성화"}
+                      </PrimaryNagativeButton>
+                      <PrimaryNagativeButton
+                        style={{ background: "#dc2626" }}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          if (
+                            confirm(
+                              `"${study.name}" 연구를 삭제할까요?\n등록된 환자·방문 데이터가 모두 함께 삭제되며 되돌릴 수 없습니다.`,
+                            )
+                          )
+                            deleteMutation.mutate(study.id);
+                        }}
+                      >
+                        삭제
+                      </PrimaryNagativeButton>
+                    </div>
+                  </div>
+                  <small style={{ color: "#6b7280" }}>
+                    {study.code ? `code: ${study.code} · ` : "code: (없음) · "}
+                    참여병원 {study._count?.study_hospital ?? 0}곳
+                    {study.active ? "" : " · (비활성)"}
+                  </small>
+                </>
+              )}
             </StudyCardDiv>
           ))}
 

--- a/src/routes/admin.tsx
+++ b/src/routes/admin.tsx
@@ -8,7 +8,7 @@ import {
 } from "../api/healthcare_professional";
 import { PrimaryButton, PrimaryNagativeButton } from "../components/button";
 import { TopDiv } from "../components/div";
-import { SearchInput } from "../components/input";
+import { SearchInput, TextInput } from "../components/input";
 import { UserContext } from "../App";
 
 import downloadIcon from "../assets/download.svg";
@@ -16,6 +16,14 @@ import { getMeasurementsByHospital } from "../api/measurement";
 import ExcelJS from "exceljs";
 import { getEthnicityList, getInstrumentList } from "../api/static";
 import AdminAuditLog from "./admin_audit_log";
+import {
+  createStudy,
+  getStudies,
+  getStudyHospitals,
+  setStudyHospitals,
+  updateStudy,
+  type Study,
+} from "../api/study";
 
 const Table = styled.table`
   width: 100%;
@@ -189,6 +197,9 @@ export default function Admin() {
         </Card>
       </div>
       <div style={{ width: "80%", marginTop: "32px" }}>
+        <StudyManagement />
+      </div>
+      <div style={{ width: "80%", marginTop: "32px" }}>
         <AdminAuditLog />
       </div>
     </TopDiv>
@@ -322,6 +333,251 @@ function HospitalCard({
         }}
       />
     </HospitalCardDiv>
+  );
+}
+
+const StudyLayout = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 24px;
+  align-items: flex-start;
+`;
+
+const StudyCardDiv = styled.div<{ $selected: boolean }>`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px 14px;
+  border: 1px solid ${(p) => (p.$selected ? "#0284c7" : "#e5e7eb")};
+  background-color: ${(p) => (p.$selected ? "#f0f9ff" : "#fff")};
+  cursor: pointer;
+  border-radius: 10px;
+  margin-bottom: 8px;
+  transition: background 0.15s, border-color 0.15s;
+  &:hover {
+    border-color: #bae6fd;
+  }
+`;
+
+const HospitalCheckRow = styled.label`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 0;
+  cursor: pointer;
+  color: #374151;
+`;
+
+function StudyManagement() {
+  const queryClient = useQueryClient();
+  const [selectedStudyId, setSelectedStudyId] = useState<string | null>(null);
+
+  const studiesQuery = useQuery({
+    queryKey: ["study", "admin"],
+    queryFn: getStudies,
+  });
+
+  const [newName, setNewName] = useState("");
+  const [newCode, setNewCode] = useState("");
+
+  const createMutation = useMutation({
+    mutationFn: () =>
+      createStudy({
+        name: newName.trim(),
+        code: newCode.trim() || undefined,
+      }),
+    onSuccess: () => {
+      setNewName("");
+      setNewCode("");
+      queryClient.invalidateQueries({ queryKey: ["study", "admin"] });
+    },
+    onError: (e: any) => alert(e?.message ?? "연구 생성 실패"),
+  });
+
+  const toggleActiveMutation = useMutation({
+    mutationFn: (study: Study) =>
+      updateStudy(study.id, { active: !study.active }),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["study", "admin"] }),
+    onError: () => alert("상태 변경 실패"),
+  });
+
+  return (
+    <Card>
+      <SectionTitle>Study Management (연구 관리)</SectionTitle>
+      <StudyLayout>
+        <div style={{ minWidth: 340 }}>
+          <h3 style={{ marginTop: 0 }}>연구 목록</h3>
+          {studiesQuery.data?.map((study) => (
+            <StudyCardDiv
+              key={study.id}
+              $selected={selectedStudyId === study.id}
+              onClick={() => setSelectedStudyId(study.id)}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "center",
+                  gap: 8,
+                }}
+              >
+                <b style={{ opacity: study.active ? 1 : 0.5 }}>{study.name}</b>
+                <PrimaryNagativeButton
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    toggleActiveMutation.mutate(study);
+                  }}
+                >
+                  {study.active ? "비활성화" : "활성화"}
+                </PrimaryNagativeButton>
+              </div>
+              <small style={{ color: "#6b7280" }}>
+                {study.code ? `code: ${study.code} · ` : ""}
+                참여병원 {study._count?.study_hospital ?? 0}곳
+                {study.active ? "" : " · (비활성)"}
+              </small>
+            </StudyCardDiv>
+          ))}
+
+          <div
+            style={{
+              marginTop: 16,
+              display: "flex",
+              flexDirection: "column",
+              gap: 8,
+            }}
+          >
+            <h4 style={{ margin: 0 }}>새 연구 추가</h4>
+            <TextInput
+              placeholder="연구명 (예: LPTAT-OS: 마이오클리어 0.05% PMS)"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+            />
+            <TextInput
+              placeholder="코드 (선택)"
+              value={newCode}
+              onChange={(e) => setNewCode(e.target.value)}
+            />
+            <PrimaryButton
+              onClick={() => newName.trim() && createMutation.mutate()}
+            >
+              추가
+            </PrimaryButton>
+          </div>
+        </div>
+
+        <div style={{ flex: 1, alignSelf: "stretch" }}>
+          {selectedStudyId ? (
+            <StudyHospitalAssign key={selectedStudyId} studyId={selectedStudyId} />
+          ) : (
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                minHeight: 180,
+                height: "100%",
+                color: "#6b7280",
+              }}
+            >
+              연구를 선택하면 참여 병원을 지정할 수 있습니다.
+            </div>
+          )}
+        </div>
+      </StudyLayout>
+    </Card>
+  );
+}
+
+function StudyHospitalAssign({ studyId }: { studyId: string }) {
+  const queryClient = useQueryClient();
+  const [search, setSearch] = useState("");
+
+  const hospitalsQuery = useQuery({
+    queryKey: ["hospital"],
+    queryFn: getHospitalList,
+  });
+
+  const assignedQuery = useQuery({
+    queryKey: ["study", studyId, "hospital"],
+    queryFn: () => getStudyHospitals(studyId),
+  });
+
+  // Local editable set, seeded from the server once loaded.
+  const [checked, setChecked] = useState<Set<string> | null>(null);
+  const effectiveChecked = useMemo(
+    () => checked ?? new Set(assignedQuery.data ?? []),
+    [checked, assignedQuery.data],
+  );
+
+  const saveMutation = useMutation({
+    mutationFn: () => setStudyHospitals(studyId, Array.from(effectiveChecked)),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["study", studyId, "hospital"],
+      });
+      queryClient.invalidateQueries({ queryKey: ["study", "admin"] });
+      alert("저장되었습니다.");
+    },
+    onError: () => alert("저장 실패"),
+  });
+
+  const toggle = (hospitalId: string) => {
+    const next = new Set(effectiveChecked);
+    next.has(hospitalId) ? next.delete(hospitalId) : next.add(hospitalId);
+    setChecked(next);
+  };
+
+  const filtered = useMemo(() => {
+    const list = (hospitalsQuery.data as any[]) ?? [];
+    if (!search) return list;
+    return list.filter(
+      (h) =>
+        h.name.toLowerCase().includes(search.toLowerCase()) ||
+        h.code.includes(search),
+    );
+  }, [hospitalsQuery.data, search]);
+
+  if (assignedQuery.isLoading || hospitalsQuery.isLoading)
+    return <div>Loading...</div>;
+
+  return (
+    <div>
+      <h3 style={{ marginTop: 0 }}>참여 병원 지정</h3>
+      <SearchInput
+        placeholder="병원 이름/코드 검색"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        style={{ width: "100%", marginBottom: 8 }}
+      />
+      <div
+        style={{
+          maxHeight: 320,
+          overflowY: "auto",
+          border: "1px solid #e5e7eb",
+          borderRadius: 10,
+          padding: "8px 14px",
+          margin: "8px 0",
+        }}
+      >
+        {filtered.map((h: any) => (
+          <HospitalCheckRow key={h.id}>
+            <input
+              type="checkbox"
+              checked={effectiveChecked.has(h.id)}
+              onChange={() => toggle(h.id)}
+            />
+            <span>
+              {h.name} ({h.code})
+            </span>
+          </HospitalCheckRow>
+        ))}
+      </div>
+      <PrimaryButton onClick={() => saveMutation.mutate()}>
+        저장 ({effectiveChecked.size}곳 선택됨)
+      </PrimaryButton>
+    </div>
   );
 }
 

--- a/src/routes/admin.tsx
+++ b/src/routes/admin.tsx
@@ -389,7 +389,7 @@ function StudyManagement() {
     mutationFn: () =>
       createStudy({
         name: newName.trim(),
-        code: newCode.trim() || undefined,
+        code: newCode.trim(),
       }),
     onSuccess: () => {
       setNewName("");
@@ -485,12 +485,18 @@ function StudyManagement() {
               onChange={(e) => setNewName(e.target.value)}
             />
             <TextInput
-              placeholder="코드 (선택)"
+              placeholder="코드 (필수, 예: LPTAT) — 연구번호 접두어로 사용됩니다"
               value={newCode}
               onChange={(e) => setNewCode(e.target.value)}
             />
             <PrimaryButton
-              onClick={() => newName.trim() && createMutation.mutate()}
+              onClick={() => {
+                if (!newName.trim() || !newCode.trim()) {
+                  alert("연구명과 코드를 모두 입력해주세요. 코드는 연구번호 접두어로 사용됩니다.");
+                  return;
+                }
+                createMutation.mutate();
+              }}
             >
               추가
             </PrimaryButton>

--- a/src/routes/admin.tsx
+++ b/src/routes/admin.tsx
@@ -16,6 +16,7 @@ import { getMeasurementsByHospital } from "../api/measurement";
 import ExcelJS from "exceljs";
 import { getEthnicityList, getInstrumentList } from "../api/static";
 import AdminAuditLog from "./admin_audit_log";
+import StudyAuditLog from "./study_audit_log";
 import {
   createStudy,
   deleteStudy,
@@ -199,6 +200,9 @@ export default function Admin() {
       </div>
       <div style={{ width: "80%", marginTop: "32px" }}>
         <StudyManagement />
+      </div>
+      <div style={{ width: "80%", marginTop: "32px" }}>
+        <StudyAuditLog />
       </div>
       <div style={{ width: "80%", marginTop: "32px" }}>
         <AdminAuditLog />

--- a/src/routes/admin.tsx
+++ b/src/routes/admin.tsx
@@ -18,6 +18,7 @@ import { getEthnicityList, getInstrumentList } from "../api/static";
 import AdminAuditLog from "./admin_audit_log";
 import {
   createStudy,
+  deleteStudy,
   getStudies,
   getStudyHospitals,
   setStudyHospitals,
@@ -402,6 +403,15 @@ function StudyManagement() {
     onError: () => alert("상태 변경 실패"),
   });
 
+  const deleteMutation = useMutation({
+    mutationFn: (studyId: string) => deleteStudy(studyId),
+    onSuccess: (_data, studyId) => {
+      if (selectedStudyId === studyId) setSelectedStudyId(null);
+      queryClient.invalidateQueries({ queryKey: ["study", "admin"] });
+    },
+    onError: () => alert("삭제 실패"),
+  });
+
   return (
     <Card>
       <SectionTitle>Study Management (연구 관리)</SectionTitle>
@@ -423,14 +433,30 @@ function StudyManagement() {
                 }}
               >
                 <b style={{ opacity: study.active ? 1 : 0.5 }}>{study.name}</b>
-                <PrimaryNagativeButton
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    toggleActiveMutation.mutate(study);
-                  }}
-                >
-                  {study.active ? "비활성화" : "활성화"}
-                </PrimaryNagativeButton>
+                <div style={{ display: "flex", gap: 6 }}>
+                  <PrimaryNagativeButton
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      toggleActiveMutation.mutate(study);
+                    }}
+                  >
+                    {study.active ? "비활성화" : "활성화"}
+                  </PrimaryNagativeButton>
+                  <PrimaryNagativeButton
+                    style={{ background: "#dc2626" }}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      if (
+                        confirm(
+                          `"${study.name}" 연구를 삭제할까요?\n등록된 환자·방문 데이터가 모두 함께 삭제되며 되돌릴 수 없습니다.`,
+                        )
+                      )
+                        deleteMutation.mutate(study.id);
+                    }}
+                  >
+                    삭제
+                  </PrimaryNagativeButton>
+                </div>
               </div>
               <small style={{ color: "#6b7280" }}>
                 {study.code ? `code: ${study.code} · ` : ""}

--- a/src/routes/chart/StudyButtons.tsx
+++ b/src/routes/chart/StudyButtons.tsx
@@ -9,6 +9,9 @@ import {
   List,
   ListItemButton,
   ListItemText,
+  Menu,
+  MenuItem,
+  Divider,
 } from "@mui/material";
 import { PrimaryButton, PrimaryNagativeButton } from "../../components/button";
 import {
@@ -29,6 +32,7 @@ export function StudyButtons({ patientId }: { patientId: string }) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
   const enrollmentsQuery = useQuery({
     queryKey: ["study", "enrollment", patientId],
@@ -65,22 +69,40 @@ export function StudyButtons({ patientId }: { patientId: string }) {
   // Nothing to show: no enrolments and no studies available to enrol into.
   if (enrollments.length === 0 && !showEnrollButton) return null;
 
-  return (
-    <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginTop: 8 }}>
-      {enrollments.map((e) => (
-        <PrimaryButton
-          key={e.id}
-          onClick={() => navigate(`/study-visit/${e.id}`)}
-        >
-          {e.study.name}
-        </PrimaryButton>
-      ))}
+  const closeMenu = () => setAnchorEl(null);
 
-      {showEnrollButton && (
-        <PrimaryNagativeButton onClick={() => setDialogOpen(true)}>
-          + 연구 등록
-        </PrimaryNagativeButton>
-      )}
+  return (
+    <div style={{ marginTop: 8 }}>
+      <PrimaryButton onClick={(e) => setAnchorEl(e.currentTarget)}>
+        연구{enrollments.length > 0 ? ` (${enrollments.length})` : ""} ▾
+      </PrimaryButton>
+
+      <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={closeMenu}>
+        {enrollments.map((e) => (
+          <MenuItem
+            key={e.id}
+            onClick={() => {
+              closeMenu();
+              navigate(`/study-visit/${e.id}`);
+            }}
+          >
+            {e.study.name}
+          </MenuItem>
+        ))}
+
+        {enrollments.length > 0 && showEnrollButton && <Divider />}
+
+        {showEnrollButton && (
+          <MenuItem
+            onClick={() => {
+              closeMenu();
+              setDialogOpen(true);
+            }}
+          >
+            + 연구 등록
+          </MenuItem>
+        )}
+      </Menu>
 
       <Dialog
         open={dialogOpen}

--- a/src/routes/chart/StudyButtons.tsx
+++ b/src/routes/chart/StudyButtons.tsx
@@ -1,0 +1,117 @@
+import { useState } from "react";
+import { useNavigate } from "react-router";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  List,
+  ListItemButton,
+  ListItemText,
+} from "@mui/material";
+import { PrimaryButton, PrimaryNagativeButton } from "../../components/button";
+import {
+  enrollPatient,
+  getAvailableStudies,
+  getEnrollments,
+} from "../../api/study";
+
+/**
+ * Study enrolment controls shown at the top-left of the chart page.
+ * - One activated button per study the patient is already enrolled in
+ *   (navigates to that study's visit data-entry page).
+ * - A "연구 등록" button — shown only when the caller's hospital has at least
+ *   one study available that this patient isn't enrolled in yet — opens a
+ *   popup to pick a study and enrol the patient.
+ */
+export function StudyButtons({ patientId }: { patientId: string }) {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const enrollmentsQuery = useQuery({
+    queryKey: ["study", "enrollment", patientId],
+    queryFn: () => getEnrollments(patientId),
+    retry: false,
+  });
+
+  const availableQuery = useQuery({
+    queryKey: ["study", "available"],
+    queryFn: getAvailableStudies,
+    retry: false,
+  });
+
+  const enrollMutation = useMutation({
+    mutationFn: (studyId: string) => enrollPatient(studyId, patientId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["study", "enrollment", patientId],
+      });
+      setDialogOpen(false);
+    },
+    onError: (e: any) => alert(e?.message ?? "연구 등록에 실패했습니다."),
+  });
+
+  const enrollments = enrollmentsQuery.data ?? [];
+  const enrolledStudyIds = new Set(enrollments.map((e) => e.study_id));
+  const available = (availableQuery.data ?? []).filter(
+    (s) => !enrolledStudyIds.has(s.id),
+  );
+
+  const showEnrollButton = available.length > 0;
+
+  // Nothing to show: no enrolments and no studies available to enrol into.
+  if (enrollments.length === 0 && !showEnrollButton) return null;
+
+  return (
+    <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginTop: 8 }}>
+      {enrollments.map((e) => (
+        <PrimaryButton
+          key={e.id}
+          onClick={() => navigate(`/study-visit/${e.id}`)}
+        >
+          {e.study.name}
+        </PrimaryButton>
+      ))}
+
+      {showEnrollButton && (
+        <PrimaryNagativeButton onClick={() => setDialogOpen(true)}>
+          + 연구 등록
+        </PrimaryNagativeButton>
+      )}
+
+      <Dialog
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+        fullWidth
+      >
+        <DialogTitle>연구 선택</DialogTitle>
+        <DialogContent>
+          {available.length === 0 ? (
+            <p>등록 가능한 연구가 없습니다.</p>
+          ) : (
+            <List>
+              {available.map((s) => (
+                <ListItemButton
+                  key={s.id}
+                  onClick={() => enrollMutation.mutate(s.id)}
+                >
+                  <ListItemText
+                    primary={s.name}
+                    secondary={s.code ?? undefined}
+                  />
+                </ListItemButton>
+              ))}
+            </List>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <PrimaryNagativeButton onClick={() => setDialogOpen(false)}>
+            취소
+          </PrimaryNagativeButton>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/routes/chart/StudyButtons.tsx
+++ b/src/routes/chart/StudyButtons.tsx
@@ -71,10 +71,33 @@ export function StudyButtons({ patientId }: { patientId: string }) {
 
   const closeMenu = () => setAnchorEl(null);
 
+  const enrolledNames = enrollments.map((e) => e.study.name);
+  const buttonLabel = enrolledNames.length
+    ? `연구 (${enrolledNames.length}): ${enrolledNames.join(", ")}`
+    : "연구";
+
   return (
     <div style={{ marginTop: 8 }}>
-      <PrimaryButton onClick={(e) => setAnchorEl(e.currentTarget)}>
-        연구{enrollments.length > 0 ? ` (${enrollments.length})` : ""} ▾
+      <PrimaryButton
+        onClick={(e) => setAnchorEl(e.currentTarget)}
+        title={enrolledNames.join(", ")}
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 6,
+          maxWidth: 380,
+        }}
+      >
+        <span
+          style={{
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {buttonLabel}
+        </span>
+        <span aria-hidden>▾</span>
       </PrimaryButton>
 
       <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={closeMenu}>

--- a/src/routes/chart/StudyButtons.tsx
+++ b/src/routes/chart/StudyButtons.tsx
@@ -33,6 +33,7 @@ export function StudyButtons({ patientId }: { patientId: string }) {
   const enrollmentsQuery = useQuery({
     queryKey: ["study", "enrollment", patientId],
     queryFn: () => getEnrollments(patientId),
+    enabled: !!patientId,
     retry: false,
   });
 

--- a/src/routes/chart/StudyButtons.tsx
+++ b/src/routes/chart/StudyButtons.tsx
@@ -71,33 +71,10 @@ export function StudyButtons({ patientId }: { patientId: string }) {
 
   const closeMenu = () => setAnchorEl(null);
 
-  const enrolledNames = enrollments.map((e) => e.study.name);
-  const buttonLabel = enrolledNames.length
-    ? `연구 (${enrolledNames.length}): ${enrolledNames.join(", ")}`
-    : "연구";
-
   return (
     <div style={{ marginTop: 8 }}>
-      <PrimaryButton
-        onClick={(e) => setAnchorEl(e.currentTarget)}
-        title={enrolledNames.join(", ")}
-        style={{
-          display: "inline-flex",
-          alignItems: "center",
-          gap: 6,
-          maxWidth: 380,
-        }}
-      >
-        <span
-          style={{
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            whiteSpace: "nowrap",
-          }}
-        >
-          {buttonLabel}
-        </span>
-        <span aria-hidden>▾</span>
+      <PrimaryButton onClick={(e) => setAnchorEl(e.currentTarget)}>
+        연구{enrollments.length > 0 ? ` (${enrollments.length})` : ""} ▾
       </PrimaryButton>
 
       <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={closeMenu}>

--- a/src/routes/chart/StudyButtons.tsx
+++ b/src/routes/chart/StudyButtons.tsx
@@ -87,6 +87,7 @@ export function StudyButtons({ patientId }: { patientId: string }) {
             }}
           >
             {e.study.name}
+            {e.subject_number ? ` · ${e.subject_number}` : ""}
           </MenuItem>
         ))}
 

--- a/src/routes/chart/index.tsx
+++ b/src/routes/chart/index.tsx
@@ -18,6 +18,7 @@ import {
   RefractiveErrorRegisterDialog,
 } from "./MeasurementList";
 import { RecentALGrowth } from "./RecentALGrowth";
+import { StudyButtons } from "./StudyButtons";
 import { TreatmentList } from "./TreatmentList";
 import { MYOPIA_STATUS_LABELS, PatientDataInput } from "./PatientDataInput";
 import {
@@ -379,6 +380,7 @@ export default function ChartRoute() {
           <ChartTitleMain>
             <h1 style={{ fontWeight: "normal" }}>Eye growth chart</h1>
             <span>{new Date().toLocaleDateString()}</span>
+            <StudyButtons patientId={patientId!} />
           </ChartTitleMain>
           <div style={{ display: "flex", flexDirection: "row", gap: "16px" }}>
             <TextButton

--- a/src/routes/study_audit_log.tsx
+++ b/src/routes/study_audit_log.tsx
@@ -1,15 +1,39 @@
 import { useState } from "react";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import styled from "styled-components";
-import { getAuditLogs, type AuditAction } from "../api/audit_log";
-import { PrimaryButton } from "../components/button";
+import {
+  AuditAction,
+  AuditLogFilters,
+  AuditStatus,
+  downloadAuditLogExport,
+  getAuditLogs,
+} from "../api/audit_log";
+import { OutlinedButton, PrimaryButton } from "../components/button";
 import { TextInput } from "../components/input";
+import { getHospitalList } from "../api/hospital";
 
 // All study-related audit tables, pulled together via the comma-separated
-// table_name filter (backend supports `in`).
+// table_name filter (backend supports `in`). Fixed — this console is scoped to
+// study activity only.
 const STUDY_TABLES = "study,study_hospital,study_enrollment,study_visit";
-const PAGE_SIZE = 20;
+const PAGE_SIZE = 50;
+
 const ACTIONS: AuditAction[] = ["CREATE", "UPDATE", "DELETE", "READ", "EXPORT"];
+const STATUSES: AuditStatus[] = ["SUCCESS", "FAILURE", "REVERTED"];
+
+const ACTION_COLORS: Record<AuditAction, string> = {
+  CREATE: "#16a34a",
+  UPDATE: "#d97706",
+  DELETE: "#dc2626",
+  READ: "#64748b",
+  EXPORT: "#7c3aed",
+};
+
+const STATUS_COLORS: Record<AuditStatus, string> = {
+  SUCCESS: "#16a34a",
+  FAILURE: "#dc2626",
+  REVERTED: "#64748b",
+};
 
 const TABLE_LABEL: Record<string, string> = {
   study: "연구",
@@ -18,34 +42,56 @@ const TABLE_LABEL: Record<string, string> = {
   study_visit: "방문데이터",
 };
 
+const Section = styled.div`
+  width: 100%;
+`;
+
+const SectionTitle = styled.h2`
+  margin: 0 0 16px 0;
+`;
+
 const Card = styled.div`
   border: 1px solid #e5e7eb;
   border-radius: 12px;
   background: #fff;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
-  padding: 20px;
+  overflow: hidden;
 `;
 
-const Head = styled.div`
+const FilterRow = styled.div`
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 12px;
-  margin-bottom: 12px;
   flex-wrap: wrap;
+  gap: 12px;
+  align-items: flex-end;
+  padding: 16px;
+  background: #f9fafb;
+  border-bottom: 1px solid #e5e7eb;
 `;
 
-const Scroll = styled.div`
+const Field = styled.label`
+  display: flex;
+  flex-direction: column;
+  font-size: 12px;
+  font-weight: 600;
+  color: #6b7280;
+  gap: 4px;
+`;
+
+const Spacer = styled.div`
+  flex: 1;
+`;
+
+const TableScroll = styled.div`
   overflow-x: auto;
 `;
 
-const Table = styled.table`
+const LogTable = styled.table`
   width: 100%;
   border-collapse: collapse;
-  font-size: 14px;
+  font-size: 13px;
   & th,
   & td {
-    padding: 8px 10px;
+    padding: 10px 12px;
     text-align: left;
     white-space: nowrap;
   }
@@ -54,6 +100,14 @@ const Table = styled.table`
     color: #374151;
     font-weight: 600;
     border-bottom: 1px solid #e5e7eb;
+    position: sticky;
+    top: 0;
+  }
+  & tbody tr:nth-child(even) {
+    background: #fafafa;
+  }
+  & tbody tr:hover {
+    background: #f0f9ff;
   }
   & tbody td {
     border-bottom: 1px solid #f0f0f0;
@@ -61,114 +115,269 @@ const Table = styled.table`
   }
 `;
 
-const Foot = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-top: 12px;
+const Badge = styled.span<{ $color: string }>`
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  color: ${(p) => p.$color};
+  background: ${(p) => p.$color}1a;
 `;
 
-const fmt = (iso: string) => new Date(iso).toLocaleString();
+const Mono = styled.span`
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  color: #6b7280;
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: inline-block;
+  vertical-align: bottom;
+`;
+
+const Pager = styled.div`
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 12px 16px;
+  border-top: 1px solid #e5e7eb;
+  font-size: 13px;
+  color: #6b7280;
+`;
+
+const Empty = styled.td`
+  text-align: center;
+  color: #9ca3af;
+  padding: 32px 12px;
+`;
+
+function formatTime(iso: string): string {
+  return new Date(iso).toLocaleString();
+}
 
 export default function StudyAuditLog() {
+  // Draft filters (the form) vs applied filters (what the query runs with).
+  const [draft, setDraft] = useState<AuditLogFilters>({});
+  const [applied, setApplied] = useState<AuditLogFilters>({});
   const [page, setPage] = useState(1);
-  const [action, setAction] = useState<AuditAction | "">("");
+  const [downloading, setDownloading] = useState(false);
+
+  // table_name is always fixed to the study tables for this console.
+  const effective: AuditLogFilters = { ...applied, table_name: STUDY_TABLES };
 
   const query = useQuery({
-    queryKey: ["study-audit", { page, action }],
-    queryFn: () =>
-      getAuditLogs(
-        { table_name: STUDY_TABLES, action: action || undefined },
-        page,
-        PAGE_SIZE,
-      ),
+    queryKey: ["study_audit_log", applied, page],
+    queryFn: () => getAuditLogs(effective, page, PAGE_SIZE),
     placeholderData: keepPreviousData,
   });
+
+  const hospitalQuery = useQuery({
+    queryKey: ["hospital"],
+    queryFn: getHospitalList,
+    staleTime: Infinity,
+  });
+  const hospitalNameById = new Map<string, string>(
+    (hospitalQuery.data ?? []).map((h: any) => [h.id, `${h.name} (${h.code})`]),
+  );
+
+  const updateDraft = (patch: Partial<AuditLogFilters>) =>
+    setDraft((prev) => ({ ...prev, ...patch }));
+
+  const applyFilters = () => {
+    setPage(1);
+    setApplied(draft);
+  };
+
+  const handleDownload = async (format: "csv" | "xlsx") => {
+    try {
+      setDownloading(true);
+      await downloadAuditLogExport(effective, format);
+    } catch (error) {
+      alert("Failed to download study log");
+      console.error(error);
+    } finally {
+      setDownloading(false);
+    }
+  };
 
   const total = query.data?.total ?? 0;
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
   return (
-    <Card>
-      <Head>
-        <h2 style={{ margin: 0 }}>스터디 로그</h2>
-        <label style={{ display: "flex", gap: 8, alignItems: "center" }}>
-          Action
-          <TextInput
-            as="select"
-            value={action}
-            onChange={(e) => {
-              setAction(e.target.value as AuditAction | "");
-              setPage(1);
-            }}
+    <Section>
+      <SectionTitle>Study Activity Log (스터디 로그)</SectionTitle>
+      <Card>
+        <FilterRow>
+          <Field>
+            Hospital
+            <TextInput
+              as="select"
+              value={draft.hospital_id ?? ""}
+              onChange={(e) =>
+                updateDraft({ hospital_id: e.target.value || undefined })
+              }
+            >
+              <option value="">All hospitals</option>
+              {hospitalQuery.data?.map((h: any) => (
+                <option key={h.id} value={h.id}>
+                  {h.name} ({h.code})
+                </option>
+              ))}
+            </TextInput>
+          </Field>
+          <Field>
+            From
+            <TextInput
+              type="date"
+              value={draft.from ?? ""}
+              onChange={(e) => updateDraft({ from: e.target.value })}
+            />
+          </Field>
+          <Field>
+            To
+            <TextInput
+              type="date"
+              value={draft.to ?? ""}
+              onChange={(e) => updateDraft({ to: e.target.value })}
+            />
+          </Field>
+          <Field>
+            Action
+            <TextInput
+              as="select"
+              value={draft.action ?? ""}
+              onChange={(e) =>
+                updateDraft({
+                  action: (e.target.value || undefined) as AuditAction,
+                })
+              }
+            >
+              <option value="">All</option>
+              {ACTIONS.map((a) => (
+                <option key={a} value={a}>
+                  {a}
+                </option>
+              ))}
+            </TextInput>
+          </Field>
+          <Field>
+            Status
+            <TextInput
+              as="select"
+              value={draft.status ?? ""}
+              onChange={(e) =>
+                updateDraft({
+                  status: (e.target.value || undefined) as AuditStatus,
+                })
+              }
+            >
+              <option value="">All</option>
+              {STATUSES.map((s) => (
+                <option key={s} value={s}>
+                  {s}
+                </option>
+              ))}
+            </TextInput>
+          </Field>
+          <PrimaryButton onClick={applyFilters}>Search</PrimaryButton>
+          <Spacer />
+          <OutlinedButton
+            disabled={downloading}
+            onClick={() => handleDownload("csv")}
           >
-            <option value="">All</option>
-            {ACTIONS.map((a) => (
-              <option key={a} value={a}>
-                {a}
-              </option>
-            ))}
-          </TextInput>
-        </label>
-      </Head>
+            Download CSV
+          </OutlinedButton>
+          <OutlinedButton
+            disabled={downloading}
+            onClick={() => handleDownload("xlsx")}
+          >
+            Download Excel
+          </OutlinedButton>
+        </FilterRow>
 
-      <Scroll>
-        <Table>
-          <thead>
-            <tr>
-              <th>시간</th>
-              <th>행위자</th>
-              <th>구분</th>
-              <th>작업</th>
-              <th>대상 ID</th>
-              <th>변경 필드</th>
-            </tr>
-          </thead>
-          <tbody>
-            {query.data?.rows.map((r) => (
-              <tr key={r.id}>
-                <td>{fmt(r.created_at)}</td>
-                <td>{r.actor_name ?? r.actor?.email ?? "-"}</td>
-                <td>{TABLE_LABEL[r.table_name] ?? r.table_name}</td>
-                <td>{r.action}</td>
-                <td title={r.record_id ?? ""}>
-                  {r.record_id ? r.record_id.slice(0, 8) : "-"}
-                </td>
-                <td>{r.changed_fields.join(", ") || "-"}</td>
-              </tr>
-            ))}
-            {query.isError && (
+        <TableScroll>
+          <LogTable>
+            <thead>
               <tr>
-                <td colSpan={6}>불러오기에 실패했습니다.</td>
+                <th>Time</th>
+                <th>Hospital</th>
+                <th>Actor</th>
+                <th>Role</th>
+                <th>Action</th>
+                <th>Status</th>
+                <th>구분</th>
+                <th>Patient</th>
+                <th>Changed fields</th>
+                <th>IP</th>
               </tr>
-            )}
-            {query.data && query.data.rows.length === 0 && (
-              <tr>
-                <td colSpan={6} style={{ color: "#6b7280" }}>
-                  스터디 로그가 없습니다.
-                </td>
-              </tr>
-            )}
-          </tbody>
-        </Table>
-      </Scroll>
+            </thead>
+            <tbody>
+              {query.data?.rows.map((r) => (
+                <tr key={r.id}>
+                  <td>{formatTime(r.created_at)}</td>
+                  <td>
+                    {r.hospital_id
+                      ? hospitalNameById.get(r.hospital_id) ?? r.hospital_id
+                      : "-"}
+                  </td>
+                  <td>{r.actor_name ?? r.actor?.email ?? "-"}</td>
+                  <td>{r.actor_role ?? "-"}</td>
+                  <td>
+                    <Badge $color={ACTION_COLORS[r.action]}>{r.action}</Badge>
+                  </td>
+                  <td>
+                    <Badge $color={STATUS_COLORS[r.status]}>{r.status}</Badge>
+                  </td>
+                  <td title={r.table_name}>
+                    {TABLE_LABEL[r.table_name] ?? r.table_name}
+                  </td>
+                  <td>
+                    {r.patient_id ? (
+                      <Mono title={r.patient_id}>{r.patient_id}</Mono>
+                    ) : (
+                      "-"
+                    )}
+                  </td>
+                  <td>{r.changed_fields.join(", ") || "-"}</td>
+                  <td>
+                    <Mono title={r.ip_address ?? ""}>{r.ip_address ?? "-"}</Mono>
+                  </td>
+                </tr>
+              ))}
+              {query.isError && (
+                <tr>
+                  <Empty colSpan={10}>Failed to load study log.</Empty>
+                </tr>
+              )}
+              {query.data && query.data.rows.length === 0 && (
+                <tr>
+                  <Empty colSpan={10}>No study logs found.</Empty>
+                </tr>
+              )}
+            </tbody>
+          </LogTable>
+        </TableScroll>
 
-      <Foot>
-        <span style={{ color: "#6b7280" }}>
-          {page} / {totalPages} · 총 {total}건
-        </span>
-        <div style={{ display: "flex", gap: 8 }}>
-          <PrimaryButton disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>
-            이전
-          </PrimaryButton>
-          <PrimaryButton
+        <Pager>
+          <span>
+            {page} / {totalPages} · {total} total
+          </span>
+          <OutlinedButton
+            disabled={page <= 1}
+            onClick={() => setPage((p) => p - 1)}
+          >
+            Prev
+          </OutlinedButton>
+          <OutlinedButton
             disabled={page >= totalPages}
             onClick={() => setPage((p) => p + 1)}
           >
-            다음
-          </PrimaryButton>
-        </div>
-      </Foot>
-    </Card>
+            Next
+          </OutlinedButton>
+        </Pager>
+      </Card>
+    </Section>
   );
 }

--- a/src/routes/study_audit_log.tsx
+++ b/src/routes/study_audit_log.tsx
@@ -1,0 +1,174 @@
+import { useState } from "react";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import styled from "styled-components";
+import { getAuditLogs, type AuditAction } from "../api/audit_log";
+import { PrimaryButton } from "../components/button";
+import { TextInput } from "../components/input";
+
+// All study-related audit tables, pulled together via the comma-separated
+// table_name filter (backend supports `in`).
+const STUDY_TABLES = "study,study_hospital,study_enrollment,study_visit";
+const PAGE_SIZE = 20;
+const ACTIONS: AuditAction[] = ["CREATE", "UPDATE", "DELETE", "READ", "EXPORT"];
+
+const TABLE_LABEL: Record<string, string> = {
+  study: "연구",
+  study_hospital: "참여병원",
+  study_enrollment: "환자등록",
+  study_visit: "방문데이터",
+};
+
+const Card = styled.div`
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  padding: 20px;
+`;
+
+const Head = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+`;
+
+const Scroll = styled.div`
+  overflow-x: auto;
+`;
+
+const Table = styled.table`
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+  & th,
+  & td {
+    padding: 8px 10px;
+    text-align: left;
+    white-space: nowrap;
+  }
+  & thead th {
+    background: #f3f4f6;
+    color: #374151;
+    font-weight: 600;
+    border-bottom: 1px solid #e5e7eb;
+  }
+  & tbody td {
+    border-bottom: 1px solid #f0f0f0;
+    color: #374151;
+  }
+`;
+
+const Foot = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 12px;
+`;
+
+const fmt = (iso: string) => new Date(iso).toLocaleString();
+
+export default function StudyAuditLog() {
+  const [page, setPage] = useState(1);
+  const [action, setAction] = useState<AuditAction | "">("");
+
+  const query = useQuery({
+    queryKey: ["study-audit", { page, action }],
+    queryFn: () =>
+      getAuditLogs(
+        { table_name: STUDY_TABLES, action: action || undefined },
+        page,
+        PAGE_SIZE,
+      ),
+    placeholderData: keepPreviousData,
+  });
+
+  const total = query.data?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  return (
+    <Card>
+      <Head>
+        <h2 style={{ margin: 0 }}>스터디 로그</h2>
+        <label style={{ display: "flex", gap: 8, alignItems: "center" }}>
+          Action
+          <TextInput
+            as="select"
+            value={action}
+            onChange={(e) => {
+              setAction(e.target.value as AuditAction | "");
+              setPage(1);
+            }}
+          >
+            <option value="">All</option>
+            {ACTIONS.map((a) => (
+              <option key={a} value={a}>
+                {a}
+              </option>
+            ))}
+          </TextInput>
+        </label>
+      </Head>
+
+      <Scroll>
+        <Table>
+          <thead>
+            <tr>
+              <th>시간</th>
+              <th>행위자</th>
+              <th>구분</th>
+              <th>작업</th>
+              <th>대상 ID</th>
+              <th>변경 필드</th>
+            </tr>
+          </thead>
+          <tbody>
+            {query.data?.rows.map((r) => (
+              <tr key={r.id}>
+                <td>{fmt(r.created_at)}</td>
+                <td>{r.actor_name ?? r.actor?.email ?? "-"}</td>
+                <td>{TABLE_LABEL[r.table_name] ?? r.table_name}</td>
+                <td>{r.action}</td>
+                <td title={r.record_id ?? ""}>
+                  {r.record_id ? r.record_id.slice(0, 8) : "-"}
+                </td>
+                <td>{r.changed_fields.join(", ") || "-"}</td>
+              </tr>
+            ))}
+            {query.isError && (
+              <tr>
+                <td colSpan={6}>불러오기에 실패했습니다.</td>
+              </tr>
+            )}
+            {query.data && query.data.rows.length === 0 && (
+              <tr>
+                <td colSpan={6} style={{ color: "#6b7280" }}>
+                  스터디 로그가 없습니다.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </Table>
+      </Scroll>
+
+      <Foot>
+        <span style={{ color: "#6b7280" }}>
+          {page} / {totalPages} · 총 {total}건
+        </span>
+        <div style={{ display: "flex", gap: 8 }}>
+          <PrimaryButton disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>
+            이전
+          </PrimaryButton>
+          <PrimaryButton
+            disabled={page >= totalPages}
+            onClick={() => setPage((p) => p + 1)}
+          >
+            다음
+          </PrimaryButton>
+        </div>
+      </Foot>
+    </Card>
+  );
+}

--- a/src/routes/study_visit/index.tsx
+++ b/src/routes/study_visit/index.tsx
@@ -1,0 +1,567 @@
+import { useContext, useEffect, useMemo, useState } from "react";
+import { useNavigate, useParams } from "react-router";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import styled from "styled-components";
+import { UserContext } from "../../App";
+import { TopDiv } from "../../components/div";
+import { PrimaryButton, PrimaryNagativeButton } from "../../components/button";
+import { TextInput } from "../../components/input";
+import { getPatientDetail } from "../../api/patient";
+import {
+  getInstrumentList,
+  getRefractiveErrorMethodList,
+} from "../../api/static";
+import {
+  createVisit,
+  getEnrollment,
+  type VisitInput,
+} from "../../api/study";
+
+const Section = styled.div`
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  background: #fff;
+  padding: 16px 20px;
+  margin-bottom: 16px;
+`;
+
+const SectionHead = styled.h3`
+  margin: 0 0 12px 0;
+  font-size: 16px;
+`;
+
+const EyeRow = styled.div`
+  display: flex;
+  gap: 24px;
+  flex-wrap: wrap;
+  align-items: center;
+`;
+
+const Field = styled.label`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: #374151;
+`;
+
+const NarrowInput = styled(TextInput)`
+  width: 90px;
+`;
+
+/** Parse a numeric field. Empty → null (N.D.). Returns ok=false if invalid. */
+function parseNum(
+  v: string,
+  min: number,
+  max: number,
+): { ok: boolean; value: number | null } {
+  if (v.trim() === "") return { ok: true, value: null };
+  const n = Number(v);
+  if (Number.isNaN(n) || n < min || n > max) return { ok: false, value: null };
+  return { ok: true, value: n };
+}
+
+function parseAxis(v: string): { ok: boolean; value: number | null } {
+  if (v.trim() === "") return { ok: true, value: null };
+  const n = Number(v);
+  if (!Number.isInteger(n) || n < 0 || n > 180) return { ok: false, value: null };
+  return { ok: true, value: n };
+}
+
+const EMPTY_FORM = {
+  va_od: "",
+  va_os: "",
+  bcva_od: "",
+  bcva_os: "",
+  ref_od_sph: "",
+  ref_od_cyl: "",
+  ref_od_axis: "",
+  ref_os_sph: "",
+  ref_os_cyl: "",
+  ref_os_axis: "",
+  iop_od: "",
+  iop_os: "",
+  accom_od: "",
+  accom_os: "",
+  al_od: "",
+  al_os: "",
+  slit_od_finding: "",
+  slit_os_finding: "",
+  concomitant_meds: "",
+  adverse_event: "",
+};
+
+export default function StudyVisit() {
+  const { enrollmentId } = useParams<{ enrollmentId: string }>();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { user } = useContext(UserContext);
+
+  const today = new Date().toISOString().slice(0, 10);
+
+  const enrollmentQuery = useQuery({
+    queryKey: ["study", "enrollment", "detail", enrollmentId],
+    queryFn: () => getEnrollment(enrollmentId!),
+    enabled: !!enrollmentId,
+  });
+  const patientId = enrollmentQuery.data?.patient_id;
+
+  const patientQuery = useQuery({
+    queryKey: ["patient", patientId],
+    queryFn: () => getPatientDetail(patientId!),
+    enabled: !!patientId,
+  });
+
+  const instrumentQuery = useQuery({
+    queryKey: ["instrument"],
+    queryFn: getInstrumentList,
+    staleTime: Infinity,
+  });
+  const methodListQuery = useQuery({
+    queryKey: ["refractive_error_method"],
+    queryFn: getRefractiveErrorMethodList,
+    staleTime: Infinity,
+  });
+
+  // Measurements newest-first. `latest` is used to PREFILL the AL fields (any
+  // date); `today` is the write-back target when a measurement already exists
+  // for today (so an older reading is never overwritten).
+  const sortedMeasurements = useMemo(
+    () =>
+      [...(patientQuery.data?.measurement ?? [])].sort(
+        (a: any, b: any) =>
+          new Date(b.date).getTime() - new Date(a.date).getTime(),
+      ),
+    [patientQuery.data],
+  );
+  const latestMeasurement = sortedMeasurements[0];
+  const todayMeasurement = useMemo(
+    () => sortedMeasurements.find((m: any) => m.date.split("T")[0] === today),
+    [sortedMeasurements, today],
+  );
+
+  // Most recent refractive error, to prefill sph/cyl/method (axis has no
+  // source in the existing data, so it stays blank).
+  const latestRE = useMemo(() => {
+    const list = [...(patientQuery.data?.refractive_error ?? [])].sort(
+      (a: any, b: any) =>
+        new Date(b.date).getTime() - new Date(a.date).getTime(),
+    );
+    return list[0];
+  }, [patientQuery.data]);
+
+  const [form, setForm] = useState(EMPTY_FORM);
+  const [method, setMethod] = useState<"Auto" | "MR" | "CR" | null>(null);
+  const [slitOdNormal, setSlitOdNormal] = useState<boolean | null>(null);
+  const [slitOsNormal, setSlitOsNormal] = useState<boolean | null>(null);
+  const [instrumentId, setInstrumentId] = useState<string>();
+  // AL values as prefilled, to detect whether the user changed them on save.
+  const [alInitial, setAlInitial] = useState({ od: "", os: "" });
+
+  const set =
+    (k: keyof typeof EMPTY_FORM) =>
+    (e: React.ChangeEvent<HTMLInputElement>) =>
+      setForm((f) => ({ ...f, [k]: e.target.value }));
+
+  // 7) Prefill AL from the most recent measurement (any date).
+  useEffect(() => {
+    if (latestMeasurement) {
+      const od = latestMeasurement.od?.toString() ?? "";
+      const os = latestMeasurement.os?.toString() ?? "";
+      setForm((f) => ({ ...f, al_od: od, al_os: os }));
+      setAlInitial({ od, os });
+    }
+  }, [latestMeasurement]);
+
+  // 3) Prefill refraction sph/cyl/method from the most recent record.
+  useEffect(() => {
+    if (!latestRE) return;
+    setForm((f) => ({
+      ...f,
+      ref_od_sph: latestRE.od_sph?.toString() ?? "",
+      ref_od_cyl: latestRE.od_cyl?.toString() ?? "",
+      ref_os_sph: latestRE.os_sph?.toString() ?? "",
+      ref_os_cyl: latestRE.os_cyl?.toString() ?? "",
+    }));
+    const methodNameMap: Record<string, "Auto" | "MR" | "CR"> = {
+      Autorefraction: "Auto",
+      "Cycloplegic refraction": "CR",
+      "Manifest refraction": "MR",
+    };
+    const name = methodListQuery.data?.find(
+      (m: any) => m.id === latestRE.method_id,
+    )?.name;
+    if (name && methodNameMap[name]) setMethod(methodNameMap[name]);
+  }, [latestRE, methodListQuery.data]);
+
+  useEffect(() => {
+    setInstrumentId(
+      user?.healthcare_professional?.default_instrument_id ??
+        instrumentQuery.data?.[0]?.id,
+    );
+  }, [instrumentQuery.data, user]);
+
+  const mutation = useMutation({
+    mutationFn: (data: VisitInput) => createVisit(enrollmentId!, data),
+    onSuccess: () => {
+      alert("저장되었습니다.");
+      queryClient.invalidateQueries({ queryKey: ["patient", patientId] });
+      navigate(`/chart/${patientId}?edit=true`);
+    },
+    onError: (e: any) => alert(e?.message ?? "저장에 실패했습니다."),
+  });
+
+  const handleSubmit = () => {
+    const errors: string[] = [];
+    const num = (key: keyof typeof EMPTY_FORM, min: number, max: number) => {
+      const r = parseNum(form[key], min, max);
+      if (!r.ok) errors.push(`${key}: ${min}~${max} 범위의 숫자만 입력하세요.`);
+      return r.value;
+    };
+    const axis = (key: keyof typeof EMPTY_FORM) => {
+      const r = parseAxis(form[key]);
+      if (!r.ok) errors.push(`${key}: 0~180 정수만 입력하세요.`);
+      return r.value;
+    };
+
+    const payload: VisitInput = {
+      visit_date: today,
+      va_od: num("va_od", 0, 1.5),
+      va_os: num("va_os", 0, 1.5),
+      bcva_od: num("bcva_od", 0, 1.5),
+      bcva_os: num("bcva_os", 0, 1.5),
+      refraction_method: method,
+      ref_od_sph: num("ref_od_sph", -30, 30),
+      ref_od_cyl: num("ref_od_cyl", -30, 30),
+      ref_od_axis: axis("ref_od_axis"),
+      ref_os_sph: num("ref_os_sph", -30, 30),
+      ref_os_cyl: num("ref_os_cyl", -30, 30),
+      ref_os_axis: axis("ref_os_axis"),
+      slitlamp_od_normal: slitOdNormal,
+      slitlamp_od_finding:
+        slitOdNormal === false ? form.slit_od_finding || null : null,
+      slitlamp_os_normal: slitOsNormal,
+      slitlamp_os_finding:
+        slitOsNormal === false ? form.slit_os_finding || null : null,
+      iop_od: num("iop_od", 0, 50),
+      iop_os: num("iop_os", 0, 50),
+      accom_od: num("accom_od", 0, 20),
+      accom_os: num("accom_os", 0, 20),
+      concomitant_meds: form.concomitant_meds || null,
+      adverse_event: form.adverse_event || null,
+    };
+
+    // 7) Axial length write-back.
+    const alOd = num("al_od", 15, 35);
+    const alOs = num("al_os", 15, 35);
+    const alUnchanged =
+      form.al_od === alInitial.od && form.al_os === alInitial.os;
+    if (alOd != null || alOs != null) {
+      if (todayMeasurement) {
+        // A reading already exists for today → update it in place.
+        payload.axial_length = {
+          measurement_id: todayMeasurement.id,
+          od: alOd,
+          os: alOs,
+        };
+      } else if (latestMeasurement && alUnchanged) {
+        // Prefilled from an older reading and left unchanged → just link to it,
+        // don't fabricate a duplicate point on the growth chart.
+        payload.axial_length = {
+          measurement_id: latestMeasurement.id,
+          od: alOd,
+          os: alOs,
+        };
+      } else if (instrumentId) {
+        // New/changed value → record it as today's measurement.
+        payload.axial_length = { instrument_id: instrumentId, od: alOd, os: alOs };
+      } else {
+        errors.push("Axial length 저장을 위한 측정기기를 선택하세요.");
+      }
+    }
+
+    if (errors.length) {
+      alert(errors.join("\n"));
+      return;
+    }
+    mutation.mutate(payload);
+  };
+
+  if (enrollmentQuery.isLoading) return <TopDiv>Loading...</TopDiv>;
+  if (enrollmentQuery.isError || !enrollmentQuery.data)
+    return <TopDiv>연구 등록 정보를 불러올 수 없습니다.</TopDiv>;
+
+  const study = enrollmentQuery.data.study;
+
+  return (
+    <TopDiv>
+      <div style={{ width: "min(760px, 92%)", padding: "16px 0 48px" }}>
+        <h1 style={{ marginBottom: 4 }}>{study.name}</h1>
+        <p style={{ color: "#6b7280", marginTop: 0 }}>
+          측정일(금일): <b>{today}</b> · 미입력 항목은 N.D.로 저장됩니다.
+        </p>
+
+        {/* 1) Snellen VA */}
+        <Section>
+          <SectionHead>1) 시력검사 (Snellen visual acuity) · 0~1.5</SectionHead>
+          <EyeRow>
+            <Field>
+              OD
+              <NarrowInput
+                inputMode="decimal"
+                value={form.va_od}
+                onChange={set("va_od")}
+              />
+            </Field>
+            <Field>
+              OS
+              <NarrowInput
+                inputMode="decimal"
+                value={form.va_os}
+                onChange={set("va_os")}
+              />
+            </Field>
+          </EyeRow>
+        </Section>
+
+        {/* 2) BCVA */}
+        <Section>
+          <SectionHead>
+            2) 최대교정시력 (Best corrected visual acuity) · 0~1.5
+          </SectionHead>
+          <EyeRow>
+            <Field>
+              OD
+              <NarrowInput
+                inputMode="decimal"
+                value={form.bcva_od}
+                onChange={set("bcva_od")}
+              />
+            </Field>
+            <Field>
+              OS
+              <NarrowInput
+                inputMode="decimal"
+                value={form.bcva_os}
+                onChange={set("bcva_os")}
+              />
+            </Field>
+          </EyeRow>
+        </Section>
+
+        {/* 3) Refraction */}
+        <Section>
+          <SectionHead>3) 굴절검사</SectionHead>
+          {latestRE && (
+            <p style={{ color: "#6b7280", marginTop: 0, fontSize: 13 }}>
+              가장 최근 굴절값({latestRE.date.split("T")[0]})의 sph/cyl/method를
+              불러왔습니다. axis는 기존 데이터에 없어 빈칸입니다.
+            </p>
+          )}
+          <div style={{ display: "flex", gap: 8, marginBottom: 12 }}>
+            {(["Auto", "MR", "CR"] as const).map((m) => (
+              <PrimaryButton
+                key={m}
+                style={{
+                  opacity: method === m ? 1 : 0.45,
+                  padding: "4px 16px",
+                }}
+                onClick={() => setMethod(method === m ? null : m)}
+              >
+                {m}
+              </PrimaryButton>
+            ))}
+          </div>
+          {(["od", "os"] as const).map((eye) => (
+            <EyeRow key={eye} style={{ marginBottom: 8 }}>
+              <b style={{ width: 28 }}>{eye.toUpperCase()}</b>
+              <Field>
+                sph
+                <NarrowInput
+                  inputMode="decimal"
+                  value={form[`ref_${eye}_sph` as keyof typeof EMPTY_FORM]}
+                  onChange={set(`ref_${eye}_sph` as keyof typeof EMPTY_FORM)}
+                />
+              </Field>
+              <Field>
+                cyl
+                <NarrowInput
+                  inputMode="decimal"
+                  value={form[`ref_${eye}_cyl` as keyof typeof EMPTY_FORM]}
+                  onChange={set(`ref_${eye}_cyl` as keyof typeof EMPTY_FORM)}
+                />
+              </Field>
+              <Field>
+                axis
+                <NarrowInput
+                  inputMode="numeric"
+                  value={form[`ref_${eye}_axis` as keyof typeof EMPTY_FORM]}
+                  onChange={set(`ref_${eye}_axis` as keyof typeof EMPTY_FORM)}
+                />
+              </Field>
+            </EyeRow>
+          ))}
+        </Section>
+
+        {/* 4) Slit lamp */}
+        <Section>
+          <SectionHead>4) 세극등 검사 (전안부)</SectionHead>
+          {(
+            [
+              ["od", slitOdNormal, setSlitOdNormal, "slit_od_finding"],
+              ["os", slitOsNormal, setSlitOsNormal, "slit_os_finding"],
+            ] as const
+          ).map(([eye, value, setValue, findingKey]) => (
+            <div key={eye} style={{ marginBottom: 10 }}>
+              <EyeRow>
+                <b style={{ width: 28 }}>{eye.toUpperCase()}</b>
+                <PrimaryButton
+                  style={{ opacity: value === true ? 1 : 0.45, padding: "4px 14px" }}
+                  onClick={() => setValue(value === true ? null : true)}
+                >
+                  정상
+                </PrimaryButton>
+                <PrimaryNagativeButton
+                  style={{ opacity: value === false ? 1 : 0.45, padding: "4px 14px" }}
+                  onClick={() => setValue(value === false ? null : false)}
+                >
+                  비정상
+                </PrimaryNagativeButton>
+                {value === false && (
+                  <TextInput
+                    style={{ flex: 1, minWidth: 180 }}
+                    placeholder="소견 (free text)"
+                    value={form[findingKey]}
+                    onChange={set(findingKey)}
+                  />
+                )}
+              </EyeRow>
+            </div>
+          ))}
+        </Section>
+
+        {/* 5) IOP */}
+        <Section>
+          <SectionHead>5) 안압검사 (mmHg) · 0.0~50.0</SectionHead>
+          <EyeRow>
+            <Field>
+              OD
+              <NarrowInput
+                inputMode="decimal"
+                value={form.iop_od}
+                onChange={set("iop_od")}
+              />
+            </Field>
+            <Field>
+              OS
+              <NarrowInput
+                inputMode="decimal"
+                value={form.iop_os}
+                onChange={set("iop_os")}
+              />
+            </Field>
+          </EyeRow>
+        </Section>
+
+        {/* 6) Accommodation */}
+        <Section>
+          <SectionHead>6) 조절력검사 (Diopters) · 0.0~20.0</SectionHead>
+          <EyeRow>
+            <Field>
+              OD
+              <NarrowInput
+                inputMode="decimal"
+                value={form.accom_od}
+                onChange={set("accom_od")}
+              />
+            </Field>
+            <Field>
+              OS
+              <NarrowInput
+                inputMode="decimal"
+                value={form.accom_os}
+                onChange={set("accom_os")}
+              />
+            </Field>
+          </EyeRow>
+        </Section>
+
+        {/* 7) Axial length */}
+        <Section>
+          <SectionHead>7) Axial length (mm) · 15~35</SectionHead>
+          <p style={{ color: "#6b7280", marginTop: 0, fontSize: 13 }}>
+            {todayMeasurement
+              ? "오늘 측정된 값을 불러왔습니다. 수정 시 오늘 데이터가 갱신됩니다."
+              : latestMeasurement
+                ? `가장 최근 측정값(${latestMeasurement.date.split("T")[0]})을 불러왔습니다. 값을 바꾸면 오늘자 측정으로 새로 저장됩니다.`
+                : "측정값이 없습니다. 입력하면 오늘자 측정으로 저장됩니다."}
+          </p>
+          <EyeRow>
+            <Field>
+              OD
+              <NarrowInput
+                inputMode="decimal"
+                value={form.al_od}
+                onChange={set("al_od")}
+              />
+            </Field>
+            <Field>
+              OS
+              <NarrowInput
+                inputMode="decimal"
+                value={form.al_os}
+                onChange={set("al_os")}
+              />
+            </Field>
+            {!todayMeasurement && (
+              <Field>
+                측정기기
+                <TextInput
+                  as="select"
+                  value={instrumentId}
+                  onChange={(e: any) => setInstrumentId(e.target.value)}
+                >
+                  {instrumentQuery.data?.map((i: any) => (
+                    <option key={i.id} value={i.id}>
+                      {i.name}
+                    </option>
+                  ))}
+                </TextInput>
+              </Field>
+            )}
+          </EyeRow>
+        </Section>
+
+        {/* 8) Concomitant meds */}
+        <Section>
+          <SectionHead>8) 병용약물</SectionHead>
+          <TextInput
+            style={{ width: "100%" }}
+            placeholder="free text"
+            value={form.concomitant_meds}
+            onChange={set("concomitant_meds")}
+          />
+        </Section>
+
+        {/* 9) Adverse event */}
+        <Section>
+          <SectionHead>9) 이상사례보고</SectionHead>
+          <TextInput
+            style={{ width: "100%" }}
+            placeholder="free text"
+            value={form.adverse_event}
+            onChange={set("adverse_event")}
+          />
+        </Section>
+
+        <div style={{ display: "flex", gap: 12, justifyContent: "flex-end" }}>
+          <PrimaryNagativeButton onClick={() => navigate(`/chart/${patientId}?edit=true`)}>
+            취소
+          </PrimaryNagativeButton>
+          <PrimaryButton onClick={handleSubmit} disabled={mutation.isPending}>
+            등록
+          </PrimaryButton>
+        </div>
+      </div>
+    </TopDiv>
+  );
+}

--- a/src/routes/study_visit/index.tsx
+++ b/src/routes/study_visit/index.tsx
@@ -342,8 +342,8 @@ export default function StudyVisit() {
     };
 
     // 7) Axial length write-back.
-    const alOd = num("al_od", 15, 35);
-    const alOs = num("al_os", 15, 35);
+    const alOd = num("al_od", 15, 40);
+    const alOs = num("al_os", 15, 40);
     const alUnchanged =
       form.al_od === alInitial.od && form.al_os === alInitial.os;
     const editingVisit = visits.find((v: any) => v.id === editingVisitId);
@@ -553,7 +553,7 @@ export default function StudyVisit() {
 
         {/* 7) Axial length */}
         <Section>
-          <SectionHead>7) Axial length (mm) · 15~35</SectionHead>
+          <SectionHead>7) Axial length (mm) · 15~40</SectionHead>
           <p style={{ color: "#6b7280", marginTop: 0, fontSize: 13 }}>
             {editingVisitId
               ? "이 방문에 연결된 측정값입니다. 수정 시 해당 측정 데이터가 갱신됩니다."

--- a/src/routes/study_visit/index.tsx
+++ b/src/routes/study_visit/index.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useMemo, useState } from "react";
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import styled from "styled-components";
@@ -14,6 +14,7 @@ import {
 import {
   createVisit,
   getEnrollment,
+  updateVisit,
   type VisitInput,
 } from "../../api/study";
 
@@ -48,6 +49,23 @@ const NarrowInput = styled(TextInput)`
   width: 90px;
 `;
 
+const VisitRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 10px 0;
+  border-bottom: 1px solid #f0f0f0;
+  &:last-child {
+    border-bottom: none;
+  }
+`;
+
+const methodNameMap: Record<string, "Auto" | "MR" | "CR"> = {
+  Autorefraction: "Auto",
+  "Cycloplegic refraction": "CR",
+  "Manifest refraction": "MR",
+};
+
 /** Parse a numeric field. Empty → null (N.D.). Returns ok=false if invalid. */
 function parseNum(
   v: string,
@@ -66,6 +84,8 @@ function parseAxis(v: string): { ok: boolean; value: number | null } {
   if (!Number.isInteger(n) || n < 0 || n > 180) return { ok: false, value: null };
   return { ok: true, value: n };
 }
+
+const nd = (v: number | null | undefined) => (v == null ? "N.D." : String(v));
 
 const EMPTY_FORM = {
   va_od: "",
@@ -104,6 +124,7 @@ export default function StudyVisit() {
     enabled: !!enrollmentId,
   });
   const patientId = enrollmentQuery.data?.patient_id;
+  const visits = enrollmentQuery.data?.visits ?? [];
 
   const patientQuery = useQuery({
     queryKey: ["patient", patientId],
@@ -122,9 +143,6 @@ export default function StudyVisit() {
     staleTime: Infinity,
   });
 
-  // Measurements newest-first. `latest` is used to PREFILL the AL fields (any
-  // date); `today` is the write-back target when a measurement already exists
-  // for today (so an older reading is never overwritten).
   const sortedMeasurements = useMemo(
     () =>
       [...(patientQuery.data?.measurement ?? [])].sort(
@@ -139,8 +157,6 @@ export default function StudyVisit() {
     [sortedMeasurements, today],
   );
 
-  // Most recent refractive error, to prefill sph/cyl/method (axis has no
-  // source in the existing data, so it stays blank).
   const latestRE = useMemo(() => {
     const list = [...(patientQuery.data?.refractive_error ?? [])].sort(
       (a: any, b: any) =>
@@ -154,44 +170,46 @@ export default function StudyVisit() {
   const [slitOdNormal, setSlitOdNormal] = useState<boolean | null>(null);
   const [slitOsNormal, setSlitOsNormal] = useState<boolean | null>(null);
   const [instrumentId, setInstrumentId] = useState<string>();
-  // AL values as prefilled, to detect whether the user changed them on save.
   const [alInitial, setAlInitial] = useState({ od: "", os: "" });
+  const [editingVisitId, setEditingVisitId] = useState<string | null>(null);
 
   const set =
     (k: keyof typeof EMPTY_FORM) =>
     (e: React.ChangeEvent<HTMLInputElement>) =>
       setForm((f) => ({ ...f, [k]: e.target.value }));
 
-  // 7) Prefill AL from the most recent measurement (any date).
-  useEffect(() => {
+  // Fresh "new visit" form, prefilled from the most recent chart data.
+  const applyNewMode = useCallback(() => {
+    setEditingVisitId(null);
+    setSlitOdNormal(null);
+    setSlitOsNormal(null);
+    const next = { ...EMPTY_FORM };
     if (latestMeasurement) {
-      const od = latestMeasurement.od?.toString() ?? "";
-      const os = latestMeasurement.os?.toString() ?? "";
-      setForm((f) => ({ ...f, al_od: od, al_os: os }));
-      setAlInitial({ od, os });
+      next.al_od = latestMeasurement.od?.toString() ?? "";
+      next.al_os = latestMeasurement.os?.toString() ?? "";
     }
-  }, [latestMeasurement]);
-
-  // 3) Prefill refraction sph/cyl/method from the most recent record.
-  useEffect(() => {
-    if (!latestRE) return;
-    setForm((f) => ({
-      ...f,
-      ref_od_sph: latestRE.od_sph?.toString() ?? "",
-      ref_od_cyl: latestRE.od_cyl?.toString() ?? "",
-      ref_os_sph: latestRE.os_sph?.toString() ?? "",
-      ref_os_cyl: latestRE.os_cyl?.toString() ?? "",
-    }));
-    const methodNameMap: Record<string, "Auto" | "MR" | "CR"> = {
-      Autorefraction: "Auto",
-      "Cycloplegic refraction": "CR",
-      "Manifest refraction": "MR",
-    };
+    if (latestRE) {
+      next.ref_od_sph = latestRE.od_sph?.toString() ?? "";
+      next.ref_od_cyl = latestRE.od_cyl?.toString() ?? "";
+      next.ref_os_sph = latestRE.os_sph?.toString() ?? "";
+      next.ref_os_cyl = latestRE.os_cyl?.toString() ?? "";
+    }
+    setForm(next);
+    setAlInitial({ od: next.al_od, os: next.al_os });
     const name = methodListQuery.data?.find(
-      (m: any) => m.id === latestRE.method_id,
+      (m: any) => m.id === latestRE?.method_id,
     )?.name;
-    if (name && methodNameMap[name]) setMethod(methodNameMap[name]);
-  }, [latestRE, methodListQuery.data]);
+    setMethod(name && methodNameMap[name] ? methodNameMap[name] : null);
+  }, [latestMeasurement, latestRE, methodListQuery.data]);
+
+  // One-time prefill once patient data is available.
+  const initialized = useRef(false);
+  useEffect(() => {
+    if (!initialized.current && patientQuery.isSuccess) {
+      initialized.current = true;
+      applyNewMode();
+    }
+  }, [patientQuery.isSuccess, applyNewMode]);
 
   useEffect(() => {
     setInstrumentId(
@@ -200,12 +218,54 @@ export default function StudyVisit() {
     );
   }, [instrumentQuery.data, user]);
 
+  // Load an existing visit into the form for editing.
+  const loadVisit = (v: any) => {
+    const linked = sortedMeasurements.find((m: any) => m.id === v.measurement_id);
+    setForm({
+      va_od: v.va_od?.toString() ?? "",
+      va_os: v.va_os?.toString() ?? "",
+      bcva_od: v.bcva_od?.toString() ?? "",
+      bcva_os: v.bcva_os?.toString() ?? "",
+      ref_od_sph: v.ref_od_sph?.toString() ?? "",
+      ref_od_cyl: v.ref_od_cyl?.toString() ?? "",
+      ref_od_axis: v.ref_od_axis?.toString() ?? "",
+      ref_os_sph: v.ref_os_sph?.toString() ?? "",
+      ref_os_cyl: v.ref_os_cyl?.toString() ?? "",
+      ref_os_axis: v.ref_os_axis?.toString() ?? "",
+      iop_od: v.iop_od?.toString() ?? "",
+      iop_os: v.iop_os?.toString() ?? "",
+      accom_od: v.accom_od?.toString() ?? "",
+      accom_os: v.accom_os?.toString() ?? "",
+      al_od: linked?.od?.toString() ?? "",
+      al_os: linked?.os?.toString() ?? "",
+      slit_od_finding: v.slitlamp_od_finding ?? "",
+      slit_os_finding: v.slitlamp_os_finding ?? "",
+      concomitant_meds: v.concomitant_meds ?? "",
+      adverse_event: v.adverse_event ?? "",
+    });
+    setAlInitial({
+      od: linked?.od?.toString() ?? "",
+      os: linked?.os?.toString() ?? "",
+    });
+    setMethod(v.refraction_method ?? null);
+    setSlitOdNormal(v.slitlamp_od_normal);
+    setSlitOsNormal(v.slitlamp_os_normal);
+    setEditingVisitId(v.id);
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
   const mutation = useMutation({
-    mutationFn: (data: VisitInput) => createVisit(enrollmentId!, data),
+    mutationFn: (data: VisitInput) =>
+      editingVisitId
+        ? updateVisit(enrollmentId!, editingVisitId, data)
+        : createVisit(enrollmentId!, data),
     onSuccess: () => {
       alert("저장되었습니다.");
+      queryClient.invalidateQueries({
+        queryKey: ["study", "enrollment", "detail", enrollmentId],
+      });
       queryClient.invalidateQueries({ queryKey: ["patient", patientId] });
-      navigate(`/chart/${patientId}?edit=true`);
+      applyNewMode();
     },
     onError: (e: any) => alert(e?.message ?? "저장에 실패했습니다."),
   });
@@ -223,8 +283,13 @@ export default function StudyVisit() {
       return r.value;
     };
 
+    const visitDate = editingVisitId
+      ? visits.find((v: any) => v.id === editingVisitId)?.visit_date.split("T")[0] ??
+        today
+      : today;
+
     const payload: VisitInput = {
-      visit_date: today,
+      visit_date: visitDate,
       va_od: num("va_od", 0, 1.5),
       va_os: num("va_os", 0, 1.5),
       bcva_od: num("bcva_od", 0, 1.5),
@@ -255,24 +320,18 @@ export default function StudyVisit() {
     const alOs = num("al_os", 15, 35);
     const alUnchanged =
       form.al_od === alInitial.od && form.al_os === alInitial.os;
+    const editingVisit = visits.find((v: any) => v.id === editingVisitId);
+    const linkedId = editingVisit?.measurement_id ?? todayMeasurement?.id ?? null;
     if (alOd != null || alOs != null) {
-      if (todayMeasurement) {
-        // A reading already exists for today → update it in place.
-        payload.axial_length = {
-          measurement_id: todayMeasurement.id,
-          od: alOd,
-          os: alOs,
-        };
-      } else if (latestMeasurement && alUnchanged) {
-        // Prefilled from an older reading and left unchanged → just link to it,
-        // don't fabricate a duplicate point on the growth chart.
+      if (linkedId) {
+        payload.axial_length = { measurement_id: linkedId, od: alOd, os: alOs };
+      } else if (!editingVisitId && latestMeasurement && alUnchanged) {
         payload.axial_length = {
           measurement_id: latestMeasurement.id,
           od: alOd,
           os: alOs,
         };
       } else if (instrumentId) {
-        // New/changed value → record it as today's measurement.
         payload.axial_length = { instrument_id: instrumentId, od: alOd, os: alOs };
       } else {
         errors.push("Axial length 저장을 위한 측정기기를 선택하세요.");
@@ -297,7 +356,21 @@ export default function StudyVisit() {
       <div style={{ width: "min(760px, 92%)", padding: "16px 0 48px" }}>
         <h1 style={{ marginBottom: 4 }}>{study.name}</h1>
         <p style={{ color: "#6b7280", marginTop: 0 }}>
-          측정일(금일): <b>{today}</b> · 미입력 항목은 N.D.로 저장됩니다.
+          {editingVisitId ? (
+            <>
+              <b>방문 수정 중</b> — 저장하면 해당 방문이 덮어써집니다.{" "}
+              <span
+                style={{ textDecoration: "underline", cursor: "pointer" }}
+                onClick={applyNewMode}
+              >
+                새 방문으로 전환
+              </span>
+            </>
+          ) : (
+            <>
+              측정일(금일): <b>{today}</b> · 미입력 항목은 N.D.로 저장됩니다.
+            </>
+          )}
         </p>
 
         {/* 1) Snellen VA */}
@@ -306,19 +379,11 @@ export default function StudyVisit() {
           <EyeRow>
             <Field>
               OD
-              <NarrowInput
-                inputMode="decimal"
-                value={form.va_od}
-                onChange={set("va_od")}
-              />
+              <NarrowInput inputMode="decimal" value={form.va_od} onChange={set("va_od")} />
             </Field>
             <Field>
               OS
-              <NarrowInput
-                inputMode="decimal"
-                value={form.va_os}
-                onChange={set("va_os")}
-              />
+              <NarrowInput inputMode="decimal" value={form.va_os} onChange={set("va_os")} />
             </Field>
           </EyeRow>
         </Section>
@@ -331,19 +396,11 @@ export default function StudyVisit() {
           <EyeRow>
             <Field>
               OD
-              <NarrowInput
-                inputMode="decimal"
-                value={form.bcva_od}
-                onChange={set("bcva_od")}
-              />
+              <NarrowInput inputMode="decimal" value={form.bcva_od} onChange={set("bcva_od")} />
             </Field>
             <Field>
               OS
-              <NarrowInput
-                inputMode="decimal"
-                value={form.bcva_os}
-                onChange={set("bcva_os")}
-              />
+              <NarrowInput inputMode="decimal" value={form.bcva_os} onChange={set("bcva_os")} />
             </Field>
           </EyeRow>
         </Section>
@@ -351,7 +408,7 @@ export default function StudyVisit() {
         {/* 3) Refraction */}
         <Section>
           <SectionHead>3) 굴절검사</SectionHead>
-          {latestRE && (
+          {latestRE && !editingVisitId && (
             <p style={{ color: "#6b7280", marginTop: 0, fontSize: 13 }}>
               가장 최근 굴절값({latestRE.date.split("T")[0]})의 sph/cyl/method를
               불러왔습니다. axis는 기존 데이터에 없어 빈칸입니다.
@@ -361,10 +418,7 @@ export default function StudyVisit() {
             {(["Auto", "MR", "CR"] as const).map((m) => (
               <PrimaryButton
                 key={m}
-                style={{
-                  opacity: method === m ? 1 : 0.45,
-                  padding: "4px 16px",
-                }}
+                style={{ opacity: method === m ? 1 : 0.45, padding: "4px 16px" }}
                 onClick={() => setMethod(method === m ? null : m)}
               >
                 {m}
@@ -445,19 +499,11 @@ export default function StudyVisit() {
           <EyeRow>
             <Field>
               OD
-              <NarrowInput
-                inputMode="decimal"
-                value={form.iop_od}
-                onChange={set("iop_od")}
-              />
+              <NarrowInput inputMode="decimal" value={form.iop_od} onChange={set("iop_od")} />
             </Field>
             <Field>
               OS
-              <NarrowInput
-                inputMode="decimal"
-                value={form.iop_os}
-                onChange={set("iop_os")}
-              />
+              <NarrowInput inputMode="decimal" value={form.iop_os} onChange={set("iop_os")} />
             </Field>
           </EyeRow>
         </Section>
@@ -468,19 +514,11 @@ export default function StudyVisit() {
           <EyeRow>
             <Field>
               OD
-              <NarrowInput
-                inputMode="decimal"
-                value={form.accom_od}
-                onChange={set("accom_od")}
-              />
+              <NarrowInput inputMode="decimal" value={form.accom_od} onChange={set("accom_od")} />
             </Field>
             <Field>
               OS
-              <NarrowInput
-                inputMode="decimal"
-                value={form.accom_os}
-                onChange={set("accom_os")}
-              />
+              <NarrowInput inputMode="decimal" value={form.accom_os} onChange={set("accom_os")} />
             </Field>
           </EyeRow>
         </Section>
@@ -489,30 +527,24 @@ export default function StudyVisit() {
         <Section>
           <SectionHead>7) Axial length (mm) · 15~35</SectionHead>
           <p style={{ color: "#6b7280", marginTop: 0, fontSize: 13 }}>
-            {todayMeasurement
-              ? "오늘 측정된 값을 불러왔습니다. 수정 시 오늘 데이터가 갱신됩니다."
-              : latestMeasurement
-                ? `가장 최근 측정값(${latestMeasurement.date.split("T")[0]})을 불러왔습니다. 값을 바꾸면 오늘자 측정으로 새로 저장됩니다.`
-                : "측정값이 없습니다. 입력하면 오늘자 측정으로 저장됩니다."}
+            {editingVisitId
+              ? "이 방문에 연결된 측정값입니다. 수정 시 해당 측정 데이터가 갱신됩니다."
+              : todayMeasurement
+                ? "오늘 측정된 값을 불러왔습니다. 수정 시 오늘 데이터가 갱신됩니다."
+                : latestMeasurement
+                  ? `가장 최근 측정값(${latestMeasurement.date.split("T")[0]})을 불러왔습니다. 값을 바꾸면 오늘자 측정으로 새로 저장됩니다.`
+                  : "측정값이 없습니다. 입력하면 오늘자 측정으로 저장됩니다."}
           </p>
           <EyeRow>
             <Field>
               OD
-              <NarrowInput
-                inputMode="decimal"
-                value={form.al_od}
-                onChange={set("al_od")}
-              />
+              <NarrowInput inputMode="decimal" value={form.al_od} onChange={set("al_od")} />
             </Field>
             <Field>
               OS
-              <NarrowInput
-                inputMode="decimal"
-                value={form.al_os}
-                onChange={set("al_os")}
-              />
+              <NarrowInput inputMode="decimal" value={form.al_os} onChange={set("al_os")} />
             </Field>
-            {!todayMeasurement && (
+            {!todayMeasurement && !editingVisitId && (
               <Field>
                 측정기기
                 <TextInput
@@ -554,13 +586,43 @@ export default function StudyVisit() {
         </Section>
 
         <div style={{ display: "flex", gap: 12, justifyContent: "flex-end" }}>
-          <PrimaryNagativeButton onClick={() => navigate(`/chart/${patientId}?edit=true`)}>
-            취소
+          <PrimaryNagativeButton
+            onClick={() => navigate(`/chart/${patientId}?edit=true`)}
+          >
+            차트로
           </PrimaryNagativeButton>
           <PrimaryButton onClick={handleSubmit} disabled={mutation.isPending}>
-            등록
+            {editingVisitId ? "수정 저장" : "등록"}
           </PrimaryButton>
         </div>
+
+        {/* Visit history */}
+        <Section style={{ marginTop: 32 }}>
+          <SectionHead>방문 기록</SectionHead>
+          {visits.length === 0 ? (
+            <p style={{ color: "#6b7280" }}>저장된 방문이 없습니다.</p>
+          ) : (
+            visits.map((v: any) => (
+              <VisitRow key={v.id}>
+                <b style={{ minWidth: 96 }}>{v.visit_date.split("T")[0]}</b>
+                <span style={{ flex: 1, color: "#374151", fontSize: 13 }}>
+                  시력 {nd(v.va_od)}/{nd(v.va_os)} · 안압 {nd(v.iop_od)}/
+                  {nd(v.iop_os)} · 조절력 {nd(v.accom_od)}/{nd(v.accom_os)}
+                  {v.adverse_event ? " · ⚠ 이상사례" : ""}
+                </span>
+                <PrimaryButton
+                  style={{
+                    padding: "4px 14px",
+                    opacity: editingVisitId === v.id ? 1 : 0.85,
+                  }}
+                  onClick={() => loadVisit(v)}
+                >
+                  {editingVisitId === v.id ? "수정 중" : "수정"}
+                </PrimaryButton>
+              </VisitRow>
+            ))
+          )}
+        </Section>
       </div>
     </TopDiv>
   );

--- a/src/routes/study_visit/index.tsx
+++ b/src/routes/study_visit/index.tsx
@@ -396,6 +396,11 @@ export default function StudyVisit() {
     <TopDiv>
       <div style={{ width: "min(760px, 92%)", padding: "16px 0 48px" }}>
         <h1 style={{ marginBottom: 4 }}>{study.name}</h1>
+        {enrollmentQuery.data.subject_number && (
+          <p style={{ color: "#6b7280", margin: "0 0 4px", fontWeight: 600 }}>
+            연구번호: {enrollmentQuery.data.subject_number}
+          </p>
+        )}
         <p style={{ color: "#6b7280", marginTop: 0 }}>
           {editingVisitId ? (
             <>

--- a/src/routes/study_visit/index.tsx
+++ b/src/routes/study_visit/index.tsx
@@ -66,15 +66,24 @@ const methodNameMap: Record<string, "Auto" | "MR" | "CR"> = {
   "Manifest refraction": "MR",
 };
 
-/** Parse a numeric field. Empty → null (N.D.). Returns ok=false if invalid. */
+/**
+ * Parse a numeric field. Empty → null (N.D.). Returns ok=false if invalid.
+ * When `maxDecimals` is given, more than that many decimal places is rejected
+ * (e.g. VA/IOP/accommodation are limited to one decimal place).
+ */
 function parseNum(
   v: string,
   min: number,
   max: number,
+  maxDecimals?: number,
 ): { ok: boolean; value: number | null } {
   if (v.trim() === "") return { ok: true, value: null };
   const n = Number(v);
   if (Number.isNaN(n) || n < min || n > max) return { ok: false, value: null };
+  if (maxDecimals != null) {
+    const decimals = (v.split(".")[1] ?? "").length;
+    if (decimals > maxDecimals) return { ok: false, value: null };
+  }
   return { ok: true, value: n };
 }
 
@@ -280,9 +289,18 @@ export default function StudyVisit() {
 
   const handleSubmit = () => {
     const errors: string[] = [];
-    const num = (key: keyof typeof EMPTY_FORM, min: number, max: number) => {
-      const r = parseNum(form[key], min, max);
-      if (!r.ok) errors.push(`${key}: ${min}~${max} 범위의 숫자만 입력하세요.`);
+    const num = (
+      key: keyof typeof EMPTY_FORM,
+      min: number,
+      max: number,
+      maxDecimals?: number,
+    ) => {
+      const r = parseNum(form[key], min, max, maxDecimals);
+      if (!r.ok) {
+        const dec =
+          maxDecimals != null ? `, 소수점 ${maxDecimals}자리까지` : "";
+        errors.push(`${key}: ${min}~${max}${dec} 숫자만 입력하세요.`);
+      }
       return r.value;
     };
     const axis = (key: keyof typeof EMPTY_FORM) => {
@@ -298,10 +316,10 @@ export default function StudyVisit() {
 
     const payload: VisitInput = {
       visit_date: visitDate,
-      va_od: num("va_od", 0, 1.5),
-      va_os: num("va_os", 0, 1.5),
-      bcva_od: num("bcva_od", 0, 1.5),
-      bcva_os: num("bcva_os", 0, 1.5),
+      va_od: num("va_od", 0, 1.5, 1),
+      va_os: num("va_os", 0, 1.5, 1),
+      bcva_od: num("bcva_od", 0, 1.5, 1),
+      bcva_os: num("bcva_os", 0, 1.5, 1),
       refraction_method: method,
       ref_od_sph: num("ref_od_sph", -30, 30),
       ref_od_cyl: num("ref_od_cyl", -30, 30),
@@ -315,10 +333,10 @@ export default function StudyVisit() {
       slitlamp_os_normal: slitOsNormal,
       slitlamp_os_finding:
         slitOsNormal === false ? form.slit_os_finding || null : null,
-      iop_od: num("iop_od", 0, 50),
-      iop_os: num("iop_os", 0, 50),
-      accom_od: num("accom_od", 0, 20),
-      accom_os: num("accom_os", 0, 20),
+      iop_od: num("iop_od", 0, 50, 1),
+      iop_os: num("iop_os", 0, 50, 1),
+      accom_od: num("accom_od", 0, 20, 1),
+      accom_os: num("accom_os", 0, 20, 1),
       concomitant_meds: form.concomitant_meds || null,
       adverse_event: form.adverse_event || null,
     };
@@ -383,7 +401,9 @@ export default function StudyVisit() {
 
         {/* 1) Snellen VA */}
         <Section>
-          <SectionHead>1) 시력검사 (Snellen visual acuity) · 0~1.5</SectionHead>
+          <SectionHead>
+            1) 시력검사 (Snellen visual acuity) · 0~1.5 · 소수점 1자리
+          </SectionHead>
           <EyeRow>
             <Field>
               OD
@@ -399,7 +419,7 @@ export default function StudyVisit() {
         {/* 2) BCVA */}
         <Section>
           <SectionHead>
-            2) 최대교정시력 (Best corrected visual acuity) · 0~1.5
+            2) 최대교정시력 (Best corrected visual acuity) · 0~1.5 · 소수점 1자리
           </SectionHead>
           <EyeRow>
             <Field>
@@ -503,7 +523,7 @@ export default function StudyVisit() {
 
         {/* 5) IOP */}
         <Section>
-          <SectionHead>5) 안압검사 (mmHg) · 0.0~50.0</SectionHead>
+          <SectionHead>5) 안압검사 (mmHg) · 0.0~50.0 · 소수점 1자리</SectionHead>
           <EyeRow>
             <Field>
               OD
@@ -518,7 +538,7 @@ export default function StudyVisit() {
 
         {/* 6) Accommodation */}
         <Section>
-          <SectionHead>6) 조절력검사 (Diopters) · 0.0~20.0</SectionHead>
+          <SectionHead>6) 조절력검사 (Diopters) · 0.0~20.0 · 소수점 1자리</SectionHead>
           <EyeRow>
             <Field>
               OD

--- a/src/routes/study_visit/index.tsx
+++ b/src/routes/study_visit/index.tsx
@@ -116,7 +116,9 @@ export default function StudyVisit() {
   const queryClient = useQueryClient();
   const { user } = useContext(UserContext);
 
-  const today = new Date().toISOString().slice(0, 10);
+  // Local date (YYYY-MM-DD). Using toISOString() would give the UTC date,
+  // which in KST mornings (before 09:00) resolves to the previous day.
+  const today = new Date().toLocaleDateString("sv-SE");
 
   const enrollmentQuery = useQuery({
     queryKey: ["study", "enrollment", "detail", enrollmentId],
@@ -205,11 +207,17 @@ export default function StudyVisit() {
   // One-time prefill once patient data is available.
   const initialized = useRef(false);
   useEffect(() => {
-    if (!initialized.current && patientQuery.isSuccess) {
+    // Wait for BOTH queries: applyNewMode needs the method list to prefill the
+    // refraction method, otherwise a slower methodListQuery misses the one-shot.
+    if (
+      !initialized.current &&
+      patientQuery.isSuccess &&
+      methodListQuery.isSuccess
+    ) {
       initialized.current = true;
       applyNewMode();
     }
-  }, [patientQuery.isSuccess, applyNewMode]);
+  }, [patientQuery.isSuccess, methodListQuery.isSuccess, applyNewMode]);
 
   useEffect(() => {
     setInstrumentId(

--- a/src/routes/study_visit/index.tsx
+++ b/src/routes/study_visit/index.tsx
@@ -13,6 +13,7 @@ import {
 } from "../../api/static";
 import {
   createVisit,
+  deleteVisit,
   getEnrollment,
   updateVisit,
   type VisitInput,
@@ -133,6 +134,9 @@ export default function StudyVisit() {
     queryKey: ["study", "enrollment", "detail", enrollmentId],
     queryFn: () => getEnrollment(enrollmentId!),
     enabled: !!enrollmentId,
+    // Each fetch records a READ (열람) log server-side; cache for 5 min so a
+    // refetch on window focus doesn't spam the audit trail.
+    staleTime: 5 * 60 * 1000,
   });
   const patientId = enrollmentQuery.data?.patient_id;
   const visits = enrollmentQuery.data?.visits ?? [];
@@ -285,6 +289,17 @@ export default function StudyVisit() {
       applyNewMode();
     },
     onError: (e: any) => alert(e?.message ?? "저장에 실패했습니다."),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (visitId: string) => deleteVisit(enrollmentId!, visitId),
+    onSuccess: (_data, visitId) => {
+      if (editingVisitId === visitId) applyNewMode();
+      queryClient.invalidateQueries({
+        queryKey: ["study", "enrollment", "detail", enrollmentId],
+      });
+    },
+    onError: () => alert("삭제에 실패했습니다."),
   });
 
   const handleSubmit = () => {
@@ -638,15 +653,30 @@ export default function StudyVisit() {
                   {nd(v.iop_os)} · 조절력 {nd(v.accom_od)}/{nd(v.accom_os)}
                   {v.adverse_event ? " · ⚠ 이상사례" : ""}
                 </span>
-                <PrimaryButton
-                  style={{
-                    padding: "4px 14px",
-                    opacity: editingVisitId === v.id ? 1 : 0.85,
-                  }}
-                  onClick={() => loadVisit(v)}
-                >
-                  {editingVisitId === v.id ? "수정 중" : "수정"}
-                </PrimaryButton>
+                <div style={{ display: "flex", gap: 6 }}>
+                  <PrimaryButton
+                    style={{
+                      padding: "4px 14px",
+                      opacity: editingVisitId === v.id ? 1 : 0.85,
+                    }}
+                    onClick={() => loadVisit(v)}
+                  >
+                    {editingVisitId === v.id ? "수정 중" : "수정"}
+                  </PrimaryButton>
+                  <PrimaryNagativeButton
+                    style={{ padding: "4px 14px", background: "#dc2626" }}
+                    onClick={() => {
+                      if (
+                        confirm(
+                          `${v.visit_date.split("T")[0]} 방문 기록을 삭제할까요?\n(안축장 측정값은 차트에 그대로 남습니다.)`,
+                        )
+                      )
+                        deleteMutation.mutate(v.id);
+                    }}
+                  >
+                    삭제
+                  </PrimaryNagativeButton>
+                </div>
               </VisitRow>
             ))
           )}


### PR DESCRIPTION
- admin: 연구 목록 관리 + 연구별 참여병원 지정
- 차트 좌측 상단 연구버튼 → 연구 선택 팝업 → 환자 등록
- 방문 입력 페이지(/study-visit/:enrollmentId): 9개 항목, 미입력 N.D., range 검증
- AL·굴절은 최근 값 프리필(axis는 소스 없어 빈칸), AL은 값 변경 시에만 오늘자 measurement로 write-back
- 방문 기록 조회 + 수정

※ 머지는 직접 해주세요. (백엔드 study-visit API PR과 함께 동작)