### PR TITLE
feat: 연구 관리 UX 개선 + 어드민 알림 임계치 설정

### DIFF
--- a/src/api/alert_setting.ts
+++ b/src/api/alert_setting.ts
@@ -1,0 +1,26 @@
+import { jsonFetchWithSession } from "../lib/fetch";
+import { API_ROOT } from "./root";
+
+export interface AlertSetting {
+  id: number;
+  axial_min: number;
+  axial_max: number;
+  axial_decrease_mm: number;
+  axial_increase_mm_per_year: number;
+  se_min: number;
+  se_progression_d_per_year: number;
+}
+
+export type AlertSettingInput = Omit<AlertSetting, "id">;
+
+export function getAlertSetting() {
+  return jsonFetchWithSession<AlertSetting>(API_ROOT + "/alert_setting");
+}
+
+export function updateAlertSetting(data: AlertSettingInput) {
+  return jsonFetchWithSession<AlertSetting>(
+    API_ROOT + "/alert_setting",
+    { method: "PUT" },
+    data,
+  );
+}

--- a/src/routes/admin.tsx
+++ b/src/routes/admin.tsx
@@ -567,7 +567,7 @@ function StudyManagement() {
     <Card>
       <SectionTitle>Study Management (연구 관리)</SectionTitle>
       <StudyLayout>
-        <div style={{ minWidth: 340 }}>
+        <div style={{ flex: 3, minWidth: 0 }}>
           <h3 style={{ marginTop: 0 }}>연구 목록</h3>
           {studiesQuery.data?.map((study) => (
             <StudyCardDiv
@@ -681,7 +681,7 @@ function StudyManagement() {
           </div>
         </div>
 
-        <div style={{ flex: 1, alignSelf: "stretch" }}>
+        <div style={{ flex: 7, minWidth: 0, alignSelf: "stretch" }}>
           {selectedStudyId ? (
             <StudyHospitalAssign key={selectedStudyId} studyId={selectedStudyId} />
           ) : (

--- a/src/routes/admin.tsx
+++ b/src/routes/admin.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { getHospitalList, getMembersByHospital } from "../api/hospital";
-import { useCallback, useContext, useMemo, useState } from "react";
+import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 import styled from "styled-components";
 import {
   deleteProfessional,
@@ -17,6 +17,12 @@ import ExcelJS from "exceljs";
 import { getEthnicityList, getInstrumentList } from "../api/static";
 import AdminAuditLog from "./admin_audit_log";
 import StudyAuditLog from "./study_audit_log";
+import {
+  AlertSetting,
+  AlertSettingInput,
+  getAlertSetting,
+  updateAlertSetting,
+} from "../api/alert_setting";
 import {
   createStudy,
   deleteStudy,
@@ -199,6 +205,9 @@ export default function Admin() {
         </Card>
       </div>
       <div style={{ width: "80%", marginTop: "32px" }}>
+        <AlertSettingManagement />
+      </div>
+      <div style={{ width: "80%", marginTop: "32px" }}>
         <StudyManagement />
       </div>
       <div style={{ width: "80%", marginTop: "32px" }}>
@@ -372,6 +381,124 @@ const HospitalCheckRow = styled.label`
   cursor: pointer;
   color: #374151;
 `;
+
+const ALERT_FIELDS: {
+  key: keyof AlertSettingInput;
+  label: string;
+  step: string;
+}[] = [
+  { key: "axial_min", label: "안축장 정상범위 하한 (mm)", step: "0.1" },
+  { key: "axial_max", label: "안축장 정상범위 상한 (mm)", step: "0.1" },
+  { key: "axial_decrease_mm", label: "안축장 직전대비 감소 경고 (mm)", step: "0.1" },
+  {
+    key: "axial_increase_mm_per_year",
+    label: "안축장 증가속도 경고 (mm/year)",
+    step: "0.1",
+  },
+  { key: "se_min", label: "SE 고도근시 임계 (D, 음수)", step: "0.25" },
+  {
+    key: "se_progression_d_per_year",
+    label: "SE 진행속도 경고 (D/year)",
+    step: "0.25",
+  },
+];
+
+function AlertSettingManagement() {
+  const queryClient = useQueryClient();
+  const settingQuery = useQuery({
+    queryKey: ["alert_setting"],
+    queryFn: getAlertSetting,
+  });
+
+  const [form, setForm] = useState<AlertSettingInput | null>(null);
+
+  // Seed the editable form once the current setting loads.
+  useEffect(() => {
+    if (settingQuery.data) {
+      const { id: _id, ...rest } = settingQuery.data as AlertSetting;
+      setForm(rest);
+    }
+  }, [settingQuery.data]);
+
+  const mutation = useMutation({
+    mutationFn: (data: AlertSettingInput) => updateAlertSetting(data),
+    onSuccess: () => {
+      alert("알림 기준이 저장되었습니다.");
+      queryClient.invalidateQueries({ queryKey: ["alert_setting"] });
+    },
+    onError: (e: any) => alert(e?.message ?? "저장 실패"),
+  });
+
+  return (
+    <Card>
+      <SectionTitle>Alert Threshold (알림 기준 설정)</SectionTitle>
+      <p style={{ color: "#6b7280", marginTop: 0 }}>
+        측정값 저장 시 이메일 알림과 차트 입력 경고 팝업이 아래 기준을 따릅니다.
+        (전역 공통 설정)
+      </p>
+      {form == null ? (
+        <p>불러오는 중…</p>
+      ) : (
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fill, minmax(260px, 1fr))",
+            gap: 12,
+            maxWidth: 720,
+          }}
+        >
+          {ALERT_FIELDS.map(({ key, label, step }) => (
+            <label
+              key={key}
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: 4,
+                fontSize: 13,
+                fontWeight: 600,
+                color: "#374151",
+              }}
+            >
+              {label}
+              <TextInput
+                type="number"
+                step={step}
+                value={String(form[key])}
+                onChange={(e) =>
+                  setForm({ ...form, [key]: Number(e.target.value) })
+                }
+              />
+            </label>
+          ))}
+          <div style={{ gridColumn: "1 / -1", display: "flex", gap: 8 }}>
+            <PrimaryButton
+              onClick={() => {
+                if (form.axial_min >= form.axial_max) {
+                  alert("안축장 정상범위 하한은 상한보다 작아야 합니다.");
+                  return;
+                }
+                mutation.mutate(form);
+              }}
+            >
+              저장
+            </PrimaryButton>
+            <PrimaryNagativeButton
+              onClick={() => {
+                if (settingQuery.data) {
+                  const { id: _id, ...rest } =
+                    settingQuery.data as AlertSetting;
+                  setForm(rest);
+                }
+              }}
+            >
+              되돌리기
+            </PrimaryNagativeButton>
+          </div>
+        </div>
+      )}
+    </Card>
+  );
+}
 
 function StudyManagement() {
   const queryClient = useQueryClient();

--- a/src/routes/admin.tsx
+++ b/src/routes/admin.tsx
@@ -625,6 +625,11 @@ function StudyManagement() {
                     >
                       삭제
                     </PrimaryNagativeButton>
+                    <PrimaryNagativeButton
+                      onClick={() => setSelectedStudyId(null)}
+                    >
+                      닫기
+                    </PrimaryNagativeButton>
                   </div>
                   <small style={{ color: "#9ca3af" }}>
                     참여병원 {study._count?.study_hospital ?? 0}곳

--- a/src/routes/admin.tsx
+++ b/src/routes/admin.tsx
@@ -802,6 +802,8 @@ function HospitalList({ onSelect }: { onSelect: (hospitalId: any) => void }) {
   });
 
   const [search, setSearch] = useState("");
+  const [expanded, setExpanded] = useState(false);
+  const COLLAPSED_COUNT = 5;
 
   const filteredData = useMemo(() => {
     if (query.data) {
@@ -819,6 +821,14 @@ function HospitalList({ onSelect }: { onSelect: (hospitalId: any) => void }) {
   if (query.isError) {
     return <div>Error: {query.error.message}</div>;
   }
+
+  // Collapse the (long) list to a few rows; searching always shows all matches.
+  const isSearching = search.trim().length > 0;
+  const visibleData =
+    expanded || isSearching ? filteredData : filteredData.slice(0, COLLAPSED_COUNT);
+  const hiddenCount = filteredData.length - visibleData.length;
+  const showToggle = !isSearching && filteredData.length > COLLAPSED_COUNT;
+
   return (
     <Card style={{ minWidth: "320px" }}>
       <SectionTitle>Hospital List</SectionTitle>
@@ -829,7 +839,7 @@ function HospitalList({ onSelect }: { onSelect: (hospitalId: any) => void }) {
         style={{ marginBottom: "12px", width: "100%" }}
       />
       <div>
-        {filteredData.map((hospital: any) => (
+        {visibleData.map((hospital: any) => (
           <HospitalCard
             key={hospital.id}
             hospital={hospital}
@@ -837,6 +847,26 @@ function HospitalList({ onSelect }: { onSelect: (hospitalId: any) => void }) {
           />
         ))}
       </div>
+      {showToggle && (
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          style={{
+            width: "100%",
+            marginTop: 8,
+            padding: "8px",
+            background: "transparent",
+            border: "1px solid #e5e7eb",
+            borderRadius: 8,
+            cursor: "pointer",
+            color: "#374151",
+            fontSize: 13,
+            fontWeight: 600,
+          }}
+        >
+          {expanded ? "접기 ▲" : `더보기 (${hiddenCount}개 더) ▼`}
+        </button>
+      )}
     </Card>
   );
 }

--- a/src/routes/admin.tsx
+++ b/src/routes/admin.tsx
@@ -550,6 +550,8 @@ function StudyManagement() {
       updateStudy(vars.id, { name: vars.name, code: vars.code }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["study", "admin"] });
+      alert("저장되었습니다.");
+      setSelectedStudyId(null); // 저장 후 요약 목록으로 복귀
     },
     onError: (e: any) => alert(e?.message ?? "수정 실패"),
   });
@@ -683,7 +685,11 @@ function StudyManagement() {
 
         <div style={{ flex: 7, minWidth: 0, alignSelf: "stretch" }}>
           {selectedStudyId ? (
-            <StudyHospitalAssign key={selectedStudyId} studyId={selectedStudyId} />
+            <StudyHospitalAssign
+              key={selectedStudyId}
+              studyId={selectedStudyId}
+              onSaved={() => setSelectedStudyId(null)}
+            />
           ) : (
             <div
               style={{
@@ -704,7 +710,13 @@ function StudyManagement() {
   );
 }
 
-function StudyHospitalAssign({ studyId }: { studyId: string }) {
+function StudyHospitalAssign({
+  studyId,
+  onSaved,
+}: {
+  studyId: string;
+  onSaved: () => void;
+}) {
   const queryClient = useQueryClient();
   const [search, setSearch] = useState("");
 
@@ -733,6 +745,7 @@ function StudyHospitalAssign({ studyId }: { studyId: string }) {
       });
       queryClient.invalidateQueries({ queryKey: ["study", "admin"] });
       alert("저장되었습니다.");
+      onSaved(); // 저장 후 요약 목록으로 복귀
     },
     onError: () => alert("저장 실패"),
   });

--- a/src/routes/admin.tsx
+++ b/src/routes/admin.tsx
@@ -385,13 +385,13 @@ function StudyManagement() {
   const [newName, setNewName] = useState("");
   const [newCode, setNewCode] = useState("");
 
-  // Inline edit of an existing study's name/code.
-  const [editingId, setEditingId] = useState<string | null>(null);
+  // Selecting a study opens it for editing (name/code) on the left card while
+  // the right panel assigns its hospitals — there is no separate 수정 button.
   const [editName, setEditName] = useState("");
   const [editCode, setEditCode] = useState("");
 
-  const startEdit = (study: Study) => {
-    setEditingId(study.id);
+  const selectStudy = (study: Study) => {
+    setSelectedStudyId(study.id);
     setEditName(study.name);
     setEditCode(study.code ?? "");
   };
@@ -422,7 +422,6 @@ function StudyManagement() {
     mutationFn: (vars: { id: string; name: string; code: string }) =>
       updateStudy(vars.id, { name: vars.name, code: vars.code }),
     onSuccess: () => {
-      setEditingId(null);
       queryClient.invalidateQueries({ queryKey: ["study", "admin"] });
     },
     onError: (e: any) => alert(e?.message ?? "수정 실패"),
@@ -447,12 +446,13 @@ function StudyManagement() {
             <StudyCardDiv
               key={study.id}
               $selected={selectedStudyId === study.id}
-              onClick={() => setSelectedStudyId(study.id)}
+              onClick={() => {
+                if (selectedStudyId !== study.id) selectStudy(study);
+              }}
             >
-              {editingId === study.id ? (
+              {selectedStudyId === study.id ? (
                 <div
                   style={{ display: "flex", flexDirection: "column", gap: 6 }}
-                  onClick={(e) => e.stopPropagation()}
                 >
                   <TextInput
                     placeholder="연구명"
@@ -464,7 +464,7 @@ function StudyManagement() {
                     value={editCode}
                     onChange={(e) => setEditCode(e.target.value)}
                   />
-                  <div style={{ display: "flex", gap: 6 }}>
+                  <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
                     <PrimaryButton
                       onClick={() => {
                         if (!editName.trim() || !editCode.trim()) {
@@ -480,62 +480,38 @@ function StudyManagement() {
                     >
                       저장
                     </PrimaryButton>
-                    <PrimaryNagativeButton onClick={() => setEditingId(null)}>
-                      취소
+                    <PrimaryNagativeButton
+                      onClick={() => toggleActiveMutation.mutate(study)}
+                    >
+                      {study.active ? "비활성화" : "활성화"}
+                    </PrimaryNagativeButton>
+                    <PrimaryNagativeButton
+                      style={{ background: "#dc2626" }}
+                      onClick={() => {
+                        if (
+                          confirm(
+                            `"${study.name}" 연구를 삭제할까요?\n등록된 환자·방문 데이터가 모두 함께 삭제되며 되돌릴 수 없습니다.`,
+                          )
+                        )
+                          deleteMutation.mutate(study.id);
+                      }}
+                    >
+                      삭제
                     </PrimaryNagativeButton>
                   </div>
                   <small style={{ color: "#9ca3af" }}>
-                    ※ 코드를 바꿔도 이미 부여된 기존 연구번호는 변경되지 않고,
-                    이후 등록되는 환자부터 새 코드가 적용됩니다.
+                    참여병원 {study._count?.study_hospital ?? 0}곳
+                    {study.active ? "" : " · (비활성)"} · 우측에서 참여병원을
+                    지정하세요. ※ 코드를 바꿔도 이미 부여된 기존 연구번호는
+                    변경되지 않고, 이후 등록되는 환자부터 새 코드가 적용됩니다.
                   </small>
                 </div>
               ) : (
                 <>
-                  <div
-                    style={{
-                      display: "flex",
-                      justifyContent: "space-between",
-                      alignItems: "center",
-                      gap: 8,
-                    }}
-                  >
-                    <b style={{ opacity: study.active ? 1 : 0.5 }}>
-                      {study.name}
-                    </b>
-                    <div style={{ display: "flex", gap: 6 }}>
-                      <PrimaryNagativeButton
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          startEdit(study);
-                        }}
-                      >
-                        수정
-                      </PrimaryNagativeButton>
-                      <PrimaryNagativeButton
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          toggleActiveMutation.mutate(study);
-                        }}
-                      >
-                        {study.active ? "비활성화" : "활성화"}
-                      </PrimaryNagativeButton>
-                      <PrimaryNagativeButton
-                        style={{ background: "#dc2626" }}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          if (
-                            confirm(
-                              `"${study.name}" 연구를 삭제할까요?\n등록된 환자·방문 데이터가 모두 함께 삭제되며 되돌릴 수 없습니다.`,
-                            )
-                          )
-                            deleteMutation.mutate(study.id);
-                        }}
-                      >
-                        삭제
-                      </PrimaryNagativeButton>
-                    </div>
-                  </div>
-                  <small style={{ color: "#6b7280" }}>
+                  <b style={{ opacity: study.active ? 1 : 0.5 }}>
+                    {study.name}
+                  </b>
+                  <small style={{ color: "#6b7280", display: "block" }}>
                     {study.code ? `code: ${study.code} · ` : "code: (없음) · "}
                     참여병원 {study._count?.study_hospital ?? 0}곳
                     {study.active ? "" : " · (비활성)"}

--- a/src/routes/admin.tsx
+++ b/src/routes/admin.tsx
@@ -625,11 +625,6 @@ function StudyManagement() {
                     >
                       삭제
                     </PrimaryNagativeButton>
-                    <PrimaryNagativeButton
-                      onClick={() => setSelectedStudyId(null)}
-                    >
-                      닫기
-                    </PrimaryNagativeButton>
                   </div>
                   <small style={{ color: "#9ca3af" }}>
                     참여병원 {study._count?.study_hospital ?? 0}곳

--- a/src/routes/chart/index.tsx
+++ b/src/routes/chart/index.tsx
@@ -8,6 +8,7 @@ import {
 import { useEffect, useMemo, useRef, useState } from "react";
 import ExcelJS from "exceljs";
 import { getLatestPatientData, getPatientDetail } from "../../api/patient";
+import { getAlertSetting } from "../../api/alert_setting";
 import { getGrowthDataEthnicityList } from "../../api/growth_data";
 import { upsertPatientK } from "../../api/mean_k";
 import { Chart } from "./Chart";
@@ -76,6 +77,10 @@ const AXIAL_QUERY = {
 function axialLengthQueryWarnings(
   next: { od: number | null; os: number | null; date: string },
   previous: Measurement | undefined,
+  // Thresholds default to the compiled-in values but are overridden with the
+  // admin-configured `alert_setting` so this popup stays in sync with the email
+  // alert criteria.
+  q: typeof AXIAL_QUERY = AXIAL_QUERY,
 ): string[] {
   const warnings: string[] = [];
   (["od", "os"] as const).forEach((eye) => {
@@ -83,9 +88,9 @@ function axialLengthQueryWarnings(
     if (value == null) return;
     const label = eye.toUpperCase();
 
-    if (value <= AXIAL_QUERY.minNormal || value >= AXIAL_QUERY.maxNormal) {
+    if (value <= q.minNormal || value >= q.maxNormal) {
       warnings.push(
-        `안축장 ${label} ${value}mm가 기준 범위(${AXIAL_QUERY.minNormal}~${AXIAL_QUERY.maxNormal}mm)를 벗어났습니다.`,
+        `안축장 ${label} ${value}mm가 기준 범위(${q.minNormal}~${q.maxNormal}mm)를 벗어났습니다.`,
       );
     }
 
@@ -94,7 +99,7 @@ function axialLengthQueryWarnings(
 
     // Round to 3 decimals to avoid float error (e.g. 24.15 - 24.05 = 0.0999…).
     const decrease = Math.round((prevValue - value) * 1000) / 1000;
-    if (decrease >= AXIAL_QUERY.decreaseMm) {
+    if (decrease >= q.decreaseMm) {
       warnings.push(
         `안축장 ${label}가 직전 측정(${previous.date.split("T")[0]}, ${prevValue}mm) 대비 ${decrease.toFixed(2)}mm 감소했습니다.`,
       );
@@ -106,14 +111,11 @@ function axialLengthQueryWarnings(
       (new Date(next.date).getTime() - new Date(previous.date).getTime()) /
       (365.25 * 24 * 60 * 60 * 1000);
     const increase = Math.round((value - prevValue) * 1000) / 1000;
-    if (
-      years >= AXIAL_QUERY.minIntervalYears &&
-      increase >= AXIAL_QUERY.minIncreaseMm
-    ) {
+    if (years >= q.minIntervalYears && increase >= q.minIncreaseMm) {
       const rate = increase / years;
-      if (rate >= AXIAL_QUERY.increaseMmPerYear) {
+      if (rate >= q.increaseMmPerYear) {
         warnings.push(
-          `안축장 ${label} 증가 속도가 ${rate.toFixed(2)}mm/year로 기준(${AXIAL_QUERY.increaseMmPerYear}mm/year)을 초과했습니다.`,
+          `안축장 ${label} 증가 속도가 ${rate.toFixed(2)}mm/year로 기준(${q.increaseMmPerYear}mm/year)을 초과했습니다.`,
         );
       }
     }
@@ -138,6 +140,25 @@ export default function ChartRoute() {
     queryFn: () => getPatientDetail(patientId as string),
     enabled: !!patientId,
   });
+
+  // Admin-configured alert thresholds; the input popup uses these so its
+  // warnings match the email alert criteria. Falls back to AXIAL_QUERY defaults.
+  const alertSettingQuery = useQuery({
+    queryKey: ["alert_setting"],
+    queryFn: getAlertSetting,
+    staleTime: 5 * 60 * 1000,
+  });
+  const axialThresholds = useMemo(() => {
+    const s = alertSettingQuery.data;
+    if (!s) return AXIAL_QUERY;
+    return {
+      ...AXIAL_QUERY,
+      minNormal: s.axial_min,
+      maxNormal: s.axial_max,
+      decreaseMm: s.axial_decrease_mm,
+      increaseMmPerYear: s.axial_increase_mm_per_year,
+    };
+  }, [alertSettingQuery.data]);
 
   const meanKValue = useMemo(() => {
     if (!patientQuery.data) return "(No data)";
@@ -614,7 +635,11 @@ export default function ChartRoute() {
             .sort(
               (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
             )[0];
-          const warnings = axialLengthQueryWarnings({ od, os, date }, previous);
+          const warnings = axialLengthQueryWarnings(
+            { od, os, date },
+            previous,
+            axialThresholds,
+          );
           if (warnings.length > 0) {
             const proceed = confirm(
               "다음 항목을 확인해주세요.\n\n" +


### PR DESCRIPTION
두 가지 프론트 작업 (함께 배포).

### 1) 연구 관리 UX 개선
- 별도 '수정' 버튼 제거, 카드 클릭 시 바로 이름/코드 인라인 편집
- 선택 카드에 저장/비활성화/삭제, 우측은 참여병원 지정

### 2) 어드민 알림 임계치 설정 (미팅 작업 ④)
- 어드민에 알림 기준 편집 폼 (안축장 범위·감소·증가속도, SE 임계·진행속도)
- 차트 입력 경고 팝업이 하드코딩 20~30 대신 서버 설정값 동기화
- 백엔드: myopiaBackend PR #19 (alert_setting)

마이그레이션 없음(프론트). 백엔드 #19와 함께 배포 필요.