### PR TITLE
fix: 모바일 사이드바 로그인 버튼 + sticky 헤더 + 가로 스크롤

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -102,13 +102,14 @@ const MobileOverlay = styled.div<{ $isOpen: boolean }>`
   right: 0;
   width: 70%;
   max-width: 300px;
-  height: 100vh;
+  height: 100dvh;
   background: white;
   z-index: 1001;
   display: flex;
   flex-direction: column;
   padding: 80px 32px 32px;
-  gap: 32px;
+  gap: 20px;
+  overflow-y: auto;
   box-shadow: -4px 0 24px rgba(0, 0, 0, 0.1);
   transform: translateX(${(props) => (props.$isOpen ? "0" : "100%")});
   transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);

--- a/src/index.css
+++ b/src/index.css
@@ -29,7 +29,10 @@ body {
 }
 
 #root {
-  height: 100dvh;
+  /* min-height (not fixed height) so #root grows with content and the sticky
+     header stays stuck for the whole scroll — a fixed 100dvh box would cut the
+     sticky range at one viewport. */
+  min-height: 100dvh;
   width: 100%;
   display: flex;
   flex-direction: column;
@@ -37,7 +40,9 @@ body {
 
 /* Guard against stray horizontal scroll from any full-bleed child.
    `clip` (not `hidden`) doesn't create a scroll container, so the sticky
-   header keeps working. */
+   header keeps working. Applied to html AND body so the scroll can't escape
+   to either. */
+html,
 body {
   max-width: 100%;
   overflow-x: clip;


### PR DESCRIPTION
실서비스 배포 후 발견된 3가지 수정 (PR #11 이후 커밋):

- 모바일 사이드바 하단 로그인 버튼이 화면 밖으로 밀리던 것: MobileOverlay height 100vh→100dvh + overflow-y auto
- sticky 헤더가 스크롤 중 사라지던 것: #root height→min-height (고정높이가 sticky 범위를 1뷰포트로 자름)
- 잔여 가로 스크롤: overflow-x: clip을 html에도 적용

프론트 전용, 마이그레이션 없음.