### PR TITLE
fix: dvh 미지원 구버전 대응(vh fallback) + pointer-events 표준값

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -126,6 +126,7 @@ const MobileMenuPortal = styled.div`
   top: 0;
   left: 0;
   right: 0;
+  height: 100vh; /* fallback for browsers without dvh (iOS Safari < 15.4) */
   height: 100dvh;
   overflow: hidden;
   pointer-events: none;
@@ -137,7 +138,7 @@ const MobileBackdrop = styled.div<{ $isOpen: boolean }>`
   inset: 0;
   background: rgba(0, 0, 0, 0.3);
   opacity: ${(props) => (props.$isOpen ? 1 : 0)};
-  pointer-events: ${(props) => (props.$isOpen ? "all" : "none")};
+  pointer-events: ${(props) => (props.$isOpen ? "auto" : "none")};
   transition: opacity 0.3s ease;
 `;
 

--- a/src/index.css
+++ b/src/index.css
@@ -32,6 +32,7 @@ body {
   /* min-height (not fixed height) so #root grows with content and the sticky
      header stays stuck for the whole scroll — a fixed 100dvh box would cut the
      sticky range at one viewport. */
+  min-height: 100vh; /* fallback for browsers without dvh (iOS Safari < 15.4) */
   min-height: 100dvh;
   width: 100%;
   display: flex;


### PR DESCRIPTION
리뷰 반영.

- dvh도 overflow:clip과 동일하게 iOS Safari 15.4+에서 도입됨. clip 미지원 기기 대응용 MobileMenuPortal이 정작 100dvh로 높이를 못 잡으면 무용지물 → MobileMenuPortal·#root에 `height:100vh` fallback을 `100dvh` 앞에 선언(cascade로 구버전=vh, 신버전=dvh)
- MobileBackdrop pointer-events: all → auto (HTML 표준값)

프론트 전용, 마이그레이션 없음.