### PR TITLE
fix: 푸터 하단 고정 + 사이드바 z-index + 라우트 변경 시 스크롤 상단

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { getCurrentUser } from "./api/auth";
 import { GOOGLE_CLIENT_ID } from "./lib/google_client_id";
 import type { UserRole } from "./types/user";
 import ConsentGate from "./components/consent_gate";
+import ScrollToTop from "./components/scroll_to_top";
 
 const Home = lazy(() => import("./routes/home"));
 const HeaderRoute = lazy(() => import("./routes/header_footer"));
@@ -58,6 +59,7 @@ const App = () => {
 
   return (
     <BrowserRouter>
+      <ScrollToTop />
       <LanguageProvider>
         <UserContext.Provider
           value={{

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -130,7 +130,9 @@ const MobileMenuPortal = styled.div`
   height: 100dvh;
   overflow: hidden;
   pointer-events: none;
-  z-index: 1000;
+  /* Above all page content — the Logo component carries z-index:1002, so the
+     open sidebar must sit higher to cover it. */
+  z-index: 2000;
 `;
 
 const MobileBackdrop = styled.div<{ $isOpen: boolean }>`

--- a/src/components/scroll_to_top.tsx
+++ b/src/components/scroll_to_top.tsx
@@ -1,0 +1,15 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router";
+
+/**
+ * Resets scroll to the top on every route (pathname) change. SPAs keep the
+ * previous scroll position by default; this restores the expected "new page
+ * starts at the top" behavior. Renders nothing.
+ */
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+  return null;
+}

--- a/src/routes/header_footer.tsx
+++ b/src/routes/header_footer.tsx
@@ -6,7 +6,11 @@ export default function HeaderFooterLayout() {
   return (
     <div
       style={{
-        height: "100%",
+        // flex:1 (not height:100%) so it fills #root whose height is now
+        // min-height, not a definite height — keeps the footer pinned to the
+        // bottom while the sticky header still works on long pages.
+        flex: 1,
+        minHeight: 0,
         display: "flex",
         flexDirection: "column",
       }}


### PR DESCRIPTION
모바일 반응형 후속 수정 (닫힌 PR #14 이후 커밋들):

- 푸터가 하단에 안 붙던 것: #root가 min-height라 height:100% 체인이 끊김 → HeaderFooterLayout을 flex:1로
- 모바일 사이드바가 페이지 로고(z-index:1002)에 가려지던 것: 사이드바 포털 z-index 1000→2000
- 라우트 변경 시 스크롤이 이전 위치에 머물던 것: ScrollToTop 컴포넌트로 상단 이동

프론트 전용, 마이그레이션 없음.