### PR TITLE
feat(admin): 배너 관리 화면 (/admin/banners)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ const RegularProfile = lazy(
 const Profile = lazy(() => import("./routes/profile"));
 const Admin = lazy(() => import("./routes/admin"));
 const AdminColumns = lazy(() => import("./routes/admin_columns"));
+const AdminBanners = lazy(() => import("./routes/admin_banners"));
 const WhoWeAre = lazy(() => import("./routes/who_we_are"));
 const Treatments = lazy(() => import("./routes/Treatments"));
 const TreatmentDetail = lazy(() => import("./routes/TreatmentDetail"));
@@ -100,6 +101,7 @@ const App = () => {
                 <Route path="/profile" element={<Profile />} />
                 <Route path="/admin" element={<Admin />} />
                 <Route path="/admin/columns" element={<AdminColumns />} />
+                <Route path="/admin/banners" element={<AdminBanners />} />
                 <Route path="/who_we_are" element={<WhoWeAre />} />
                 <Route path="/treatments" element={<Treatments />} />
                 <Route path="/treatments/:id" element={<TreatmentDetail />} />

--- a/src/api/banner.ts
+++ b/src/api/banner.ts
@@ -1,0 +1,59 @@
+import { jsonFetchWithSession } from "../lib/fetch";
+import { API_ROOT } from "./root";
+
+export interface AdBanner {
+  id: string;
+  title: string;
+  subtitle: string | null;
+  badge_text: string | null;
+  image_url: string;
+  link_url: string;
+  placement: string;
+  sort_order: number;
+  active: boolean;
+  start_at: string | null;
+  end_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface BannerInput {
+  title: string;
+  subtitle?: string;
+  badge_text?: string;
+  image_url: string;
+  link_url: string;
+  placement?: string;
+  sort_order?: number;
+  active?: boolean;
+  start_at?: string | null;
+  end_at?: string | null;
+}
+
+export function listBanners(): Promise<AdBanner[]> {
+  return jsonFetchWithSession(API_ROOT + "/banner");
+}
+
+export function getBanner(id: string): Promise<AdBanner> {
+  return jsonFetchWithSession(API_ROOT + "/banner/" + id);
+}
+
+export function createBanner(data: BannerInput): Promise<AdBanner> {
+  return jsonFetchWithSession(API_ROOT + "/banner", { method: "POST" }, data);
+}
+
+export function updateBanner(
+  id: string,
+  data: Partial<BannerInput>,
+): Promise<AdBanner> {
+  return jsonFetchWithSession(API_ROOT + "/banner/" + id, { method: "PATCH" }, data);
+}
+
+export function deleteBanner(id: string): Promise<void> {
+  return jsonFetchWithSession(
+    API_ROOT + "/banner/" + id,
+    { method: "DELETE" },
+    undefined,
+    false,
+  );
+}

--- a/src/routes/admin.tsx
+++ b/src/routes/admin.tsx
@@ -145,6 +145,8 @@ export default function Admin() {
     <TopDiv>
       <h1>Admin Page</h1>
       <a href="/admin/columns" style={{ display: "inline-block", marginBottom: 12, color: "#0d47a1" }}>칼럼 관리 →</a>
+      <br />
+      <a href="/admin/banners" style={{ display: "inline-block", marginBottom: 12, color: "#0d47a1" }}>배너 관리 →</a>
       <TopRow>
         <HospitalList onSelect={setSelectedHospitalId} />
         <Card style={{ flex: 1, minWidth: 0 }}>

--- a/src/routes/admin_banners.tsx
+++ b/src/routes/admin_banners.tsx
@@ -1,0 +1,230 @@
+import { useContext, useState, type CSSProperties, type ReactNode } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { UserContext } from "../App";
+import { PrimaryButton, PrimaryNagativeButton } from "../components/button";
+import {
+  createBanner,
+  deleteBanner,
+  listBanners,
+  updateBanner,
+  type AdBanner,
+  type BannerInput,
+} from "../api/banner";
+
+const EMPTY: BannerInput = {
+  title: "",
+  subtitle: "",
+  badge_text: "",
+  image_url: "",
+  link_url: "",
+  placement: "home",
+  sort_order: 0,
+  active: true,
+};
+
+export default function AdminBanners() {
+  const { user } = useContext(UserContext);
+  const qc = useQueryClient();
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [form, setForm] = useState<BannerInput>(EMPTY);
+
+  const listQuery = useQuery({ queryKey: ["admin", "banners"], queryFn: listBanners });
+
+  const saveMutation = useMutation({
+    mutationFn: () =>
+      editingId ? updateBanner(editingId, form) : createBanner(form),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["admin", "banners"] });
+      reset();
+    },
+  });
+
+  const delMutation = useMutation({
+    mutationFn: (id: string) => deleteBanner(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["admin", "banners"] }),
+  });
+
+  function reset() {
+    setEditingId(null);
+    setForm(EMPTY);
+  }
+
+  function startEdit(b: AdBanner) {
+    setEditingId(b.id);
+    setForm({
+      title: b.title,
+      subtitle: b.subtitle ?? "",
+      badge_text: b.badge_text ?? "",
+      image_url: b.image_url,
+      link_url: b.link_url,
+      placement: b.placement,
+      sort_order: b.sort_order,
+      active: b.active,
+      start_at: b.start_at,
+      end_at: b.end_at,
+    });
+  }
+
+  if (!user?.is_site_admin) {
+    return <div style={{ padding: 24 }}>Not authorized</div>;
+  }
+
+  const setText = (k: keyof BannerInput) => (e: any) =>
+    setForm((f) => ({ ...f, [k]: e.target.value }));
+
+  const canSave =
+    !!form.title.trim() && !!form.image_url.trim() && !!form.link_url.trim();
+
+  return (
+    <div style={{ padding: 24, maxWidth: 900, margin: "0 auto" }}>
+      <h1>배너 관리</h1>
+
+      <div style={card}>
+        <h2>{editingId ? "배너 수정" : "새 배너"}</h2>
+        <Field label="제목">
+          <input value={form.title} onChange={setText("title")} style={inp} />
+        </Field>
+        <Field label="서브타이틀">
+          <input value={form.subtitle} onChange={setText("subtitle")} style={inp} />
+        </Field>
+        <Field label="배지 텍스트 (예: 기간 할인)">
+          <input value={form.badge_text} onChange={setText("badge_text")} style={inp} />
+        </Field>
+        <Field label="이미지 URL">
+          <input value={form.image_url} onChange={setText("image_url")} style={inp} />
+        </Field>
+        <Field label="연결 링크 URL">
+          <input value={form.link_url} onChange={setText("link_url")} style={inp} />
+        </Field>
+        <div style={{ display: "flex", gap: 12 }}>
+          <Field label="노출 위치">
+            <input
+              value={form.placement}
+              onChange={setText("placement")}
+              style={inp}
+              placeholder="home"
+            />
+          </Field>
+          <Field label="정렬 순서 (낮을수록 먼저)">
+            <input
+              type="number"
+              value={form.sort_order}
+              onChange={(e) =>
+                setForm((f) => ({ ...f, sort_order: Number(e.target.value) || 0 }))
+              }
+              style={inp}
+            />
+          </Field>
+        </div>
+        <div style={{ display: "flex", gap: 12 }}>
+          <Field label="시작일시 (비우면 즉시)">
+            <input
+              type="datetime-local"
+              value={form.start_at ? form.start_at.slice(0, 16) : ""}
+              onChange={(e) =>
+                setForm((f) => ({
+                  ...f,
+                  start_at: e.target.value ? new Date(e.target.value).toISOString() : null,
+                }))
+              }
+              style={inp}
+            />
+          </Field>
+          <Field label="종료일시 (비우면 무기한)">
+            <input
+              type="datetime-local"
+              value={form.end_at ? form.end_at.slice(0, 16) : ""}
+              onChange={(e) =>
+                setForm((f) => ({
+                  ...f,
+                  end_at: e.target.value ? new Date(e.target.value).toISOString() : null,
+                }))
+              }
+              style={inp}
+            />
+          </Field>
+        </div>
+        <label style={{ display: "flex", alignItems: "center", gap: 8, margin: "8px 0" }}>
+          <input
+            type="checkbox"
+            checked={!!form.active}
+            onChange={(e) => setForm((f) => ({ ...f, active: e.target.checked }))}
+          />
+          활성 (체크 해제 시 앱에 노출되지 않음)
+        </label>
+        <div style={{ display: "flex", gap: 8, marginTop: 8 }}>
+          <PrimaryButton onClick={() => canSave && saveMutation.mutate()}>
+            {editingId ? "수정 저장" : "생성"}
+          </PrimaryButton>
+          {editingId && <PrimaryNagativeButton onClick={reset}>취소</PrimaryNagativeButton>}
+        </div>
+        {saveMutation.isError && <p style={{ color: "red" }}>저장에 실패했습니다.</p>}
+      </div>
+
+      <h2 style={{ marginTop: 28 }}>배너 목록</h2>
+      {listQuery.isLoading ? (
+        <div>Loading…</div>
+      ) : (
+        <table style={{ width: "100%", borderCollapse: "collapse" }}>
+          <thead>
+            <tr>
+              <th style={th}>제목</th>
+              <th style={th}>위치</th>
+              <th style={th}>순서</th>
+              <th style={th}>활성</th>
+              <th style={th} />
+            </tr>
+          </thead>
+          <tbody>
+            {listQuery.data?.map((b) => (
+              <tr key={b.id}>
+                <td style={td}>{b.title}</td>
+                <td style={td}>{b.placement}</td>
+                <td style={td}>{b.sort_order}</td>
+                <td style={td}>{b.active ? "O" : "-"}</td>
+                <td style={{ ...td, whiteSpace: "nowrap" }}>
+                  <PrimaryButton onClick={() => startEdit(b)}>수정</PrimaryButton>{" "}
+                  <PrimaryNagativeButton
+                    onClick={() => {
+                      if (confirm("이 배너를 삭제할까요?")) delMutation.mutate(b.id);
+                    }}
+                  >
+                    삭제
+                  </PrimaryNagativeButton>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div style={{ marginBottom: 10, flex: 1 }}>
+      <label style={{ display: "block", fontSize: 13, color: "#555", marginBottom: 4 }}>
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+}
+
+const card: CSSProperties = {
+  border: "1px solid #ddd",
+  borderRadius: 8,
+  padding: 16,
+  marginTop: 12,
+};
+const inp: CSSProperties = {
+  width: "100%",
+  padding: 8,
+  border: "1px solid #ccc",
+  borderRadius: 6,
+  boxSizing: "border-box",
+};
+const th: CSSProperties = { textAlign: "left", borderBottom: "2px solid #eee", padding: 8 };
+const td: CSSProperties = { borderBottom: "1px solid #eee", padding: 8 };

--- a/src/routes/admin_banners.tsx
+++ b/src/routes/admin_banners.tsx
@@ -12,6 +12,18 @@ import {
   type BannerInput,
 } from "../api/banner";
 
+// <input type="datetime-local"> shows/edits a naive local wall-clock string
+// (no timezone), while the API stores UTC ISO strings. toISOString() on the
+// typed value already round-trips correctly (the browser parses the naive
+// string as local time), but the reverse — pre-filling the input from a
+// stored UTC ISO string — needs an explicit local-time format, otherwise the
+// input shows the raw UTC clock time as if it were local (e.g. off by 9h in KST).
+function toLocalInputValue(iso: string): string {
+  const d = new Date(iso);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
 const EMPTY: BannerInput = {
   title: "",
   subtitle: "",
@@ -121,7 +133,7 @@ export default function AdminBanners() {
           <Field label="시작일시 (비우면 즉시)">
             <input
               type="datetime-local"
-              value={form.start_at ? form.start_at.slice(0, 16) : ""}
+              value={form.start_at ? toLocalInputValue(form.start_at) : ""}
               onChange={(e) =>
                 setForm((f) => ({
                   ...f,
@@ -134,7 +146,7 @@ export default function AdminBanners() {
           <Field label="종료일시 (비우면 무기한)">
             <input
               type="datetime-local"
-              value={form.end_at ? form.end_at.slice(0, 16) : ""}
+              value={form.end_at ? toLocalInputValue(form.end_at) : ""}
               onChange={(e) =>
                 setForm((f) => ({
                   ...f,


### PR DESCRIPTION
## 요약
- 강남언니 스타일 홈 배너를 관리자가 등록/수정할 수 있는 화면 추가
- `/admin/banners` — 칼럼 관리(`/admin/columns`)와 동일한 UI 패턴 (목록 + 생성/수정 폼)
- `/admin` 페이지에 "배너 관리 →" 링크 추가

## 의존성
- **myopiaBackend PR #24** (jin0008/myopiaBackend `feat/ad-banners`)의 `/banner` API가 먼저 배포되어야 정상 동작합니다. 백엔드 PR 머지·배포 전까지는 이 화면에서 목록/저장이 실패해요.

## 범위 밖
- 이미지는 외부 URL만 지원 (업로드 파이프라인 없음)

## 테스트
- [ ] 백엔드 배포 후 배너 생성/수정/삭제 확인
- [ ] `is_site_admin` 아닌 계정으로 접근 시 차단 확인