### PR TITLE
feat(admin): 배너 이미지 파일 업로드 UI

### DIFF
--- a/src/api/banner.ts
+++ b/src/api/banner.ts
@@ -1,4 +1,4 @@
-import { jsonFetchWithSession } from "../lib/fetch";
+import { AuthorizationError, HttpError, jsonFetchWithSession } from "../lib/fetch";
 import { API_ROOT } from "./root";
 
 export interface AdBanner {
@@ -47,6 +47,30 @@ export function updateBanner(
   data: Partial<BannerInput>,
 ): Promise<AdBanner> {
   return jsonFetchWithSession(API_ROOT + "/banner/" + id, { method: "PATCH" }, data);
+}
+
+// Not jsonFetchWithSession — that always JSON.stringifies the body and sets
+// Content-Type: application/json, which breaks a multipart file upload.
+export async function uploadBannerImage(file: File): Promise<{ url: string }> {
+  const session_key = localStorage.getItem("session_key");
+  if (!session_key) throw new AuthorizationError("Authorization error");
+
+  const body = new FormData();
+  body.append("image", file);
+
+  const result = await fetch(API_ROOT + "/banner/upload", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${session_key}` },
+    body,
+  });
+  if (result.status === 401 || result.status === 403) {
+    throw new AuthorizationError("Authorization error");
+  }
+  if (!result.ok) {
+    const respBody = await result.json().catch(() => ({}));
+    throw new HttpError(result.status, respBody?.message);
+  }
+  return result.json();
 }
 
 export function deleteBanner(id: string): Promise<void> {

--- a/src/routes/admin_banners.tsx
+++ b/src/routes/admin_banners.tsx
@@ -8,6 +8,7 @@ import {
   deleteBanner,
   listBanners,
   updateBanner,
+  uploadBannerImage,
   type AdBanner,
   type BannerInput,
 } from "../api/banner";
@@ -57,6 +58,12 @@ export default function AdminBanners() {
     onSuccess: () => qc.invalidateQueries({ queryKey: ["admin", "banners"] }),
   });
 
+  const uploadMutation = useMutation({
+    mutationFn: (file: File) => uploadBannerImage(file),
+    onSuccess: ({ url }) => setForm((f) => ({ ...f, image_url: url })),
+    onError: (e: any) => alert(e?.message ?? "이미지 업로드 실패"),
+  });
+
   function reset() {
     setEditingId(null);
     setForm(EMPTY);
@@ -103,8 +110,41 @@ export default function AdminBanners() {
         <Field label="배지 텍스트 (예: 기간 할인)">
           <input value={form.badge_text} onChange={setText("badge_text")} style={inp} />
         </Field>
-        <Field label="이미지 URL">
-          <input value={form.image_url} onChange={setText("image_url")} style={inp} />
+        <Field label="이미지">
+          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+            <input
+              value={form.image_url}
+              onChange={setText("image_url")}
+              style={{ ...inp, flex: 1 }}
+              placeholder="파일 업로드 또는 이미지 URL 직접 입력"
+            />
+            <label
+              style={{
+                ...uploadBtn,
+                opacity: uploadMutation.isPending ? 0.6 : 1,
+                pointerEvents: uploadMutation.isPending ? "none" : "auto",
+              }}
+            >
+              {uploadMutation.isPending ? "업로드 중…" : "파일 선택"}
+              <input
+                type="file"
+                accept="image/*"
+                style={{ display: "none" }}
+                onChange={(e) => {
+                  const file = e.target.files?.[0];
+                  if (file) uploadMutation.mutate(file);
+                  e.target.value = "";
+                }}
+              />
+            </label>
+          </div>
+          {form.image_url ? (
+            <img
+              src={form.image_url}
+              alt=""
+              style={{ marginTop: 8, maxWidth: 240, maxHeight: 140, borderRadius: 8, display: "block" }}
+            />
+          ) : null}
         </Field>
         <Field label="연결 링크 URL">
           <input value={form.link_url} onChange={setText("link_url")} style={inp} />
@@ -237,6 +277,16 @@ const inp: CSSProperties = {
   border: "1px solid #ccc",
   borderRadius: 6,
   boxSizing: "border-box",
+};
+const uploadBtn: CSSProperties = {
+  flexShrink: 0,
+  padding: "8px 14px",
+  border: "1px solid #ccc",
+  borderRadius: 6,
+  background: "#f3f4f6",
+  cursor: "pointer",
+  fontSize: 13,
+  whiteSpace: "nowrap",
 };
 const th: CSSProperties = { textAlign: "left", borderBottom: "2px solid #eee", padding: 8 };
 const td: CSSProperties = { borderBottom: "1px solid #eee", padding: 8 };


### PR DESCRIPTION
## 요약
- `/admin/banners`의 이미지 URL 입력칸 옆에 "파일 선택" 버튼 추가
- 파일 선택 시 서버로 업로드하고, 응답받은 URL을 자동으로 이미지 URL 필드에 채움
- URL 직접 붙여넣기도 그대로 가능 (선택사항)
- 미리보기 썸네일 표시

## 의존성
- myopiaBackend PR #25 (`/banner/upload`, `/banner/uploads/:filename`)이 먼저 배포되어야 동작

## 테스트
- [ ] 파일 선택 → 업로드 → URL 자동 채워짐 → 미리보기 표시 확인
- [ ] 업로드 실패 시(5MB 초과 등) 에러 알림 확인