### PR TITLE
feat(partner): 파트너 승인 화면 + 파트너 포털 (Phase 2 프론트)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,9 @@ const AdminColumns = lazy(() => import("./routes/admin_columns"));
 const AdminBanners = lazy(() => import("./routes/admin_banners"));
 const AdminHospitalProfiles = lazy(() => import("./routes/admin_hospital_profiles"));
 const AdminPartnerAccounts = lazy(() => import("./routes/admin_partner_accounts"));
+const PartnerLogin = lazy(() => import("./routes/partner/PartnerLogin"));
+const PartnerSignup = lazy(() => import("./routes/partner/PartnerSignup"));
+const PartnerProfile = lazy(() => import("./routes/partner/PartnerProfile"));
 const WhoWeAre = lazy(() => import("./routes/who_we_are"));
 const Treatments = lazy(() => import("./routes/Treatments"));
 const TreatmentDetail = lazy(() => import("./routes/TreatmentDetail"));
@@ -117,6 +120,11 @@ const App = () => {
                 <Route path="/user-guide" element={<UserGuide />} />
                 <Route path="/tos" element={<TOS />} />
               </Route>
+              {/* Partner portal — its own login/layout, separate from the
+                  doctor/admin app (no shared header). */}
+              <Route path="/partner/login" element={<PartnerLogin />} />
+              <Route path="/partner/signup" element={<PartnerSignup />} />
+              <Route path="/partner/profile" element={<PartnerProfile />} />
             </Routes>
             </Suspense>
           </GoogleOAuthProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,7 @@ const AdminMyodoc = lazy(() => import("./routes/admin_myodoc"));
 const AdminColumns = lazy(() => import("./routes/admin_columns"));
 const AdminBanners = lazy(() => import("./routes/admin_banners"));
 const AdminHospitalProfiles = lazy(() => import("./routes/admin_hospital_profiles"));
+const AdminPartnerAccounts = lazy(() => import("./routes/admin_partner_accounts"));
 const WhoWeAre = lazy(() => import("./routes/who_we_are"));
 const Treatments = lazy(() => import("./routes/Treatments"));
 const TreatmentDetail = lazy(() => import("./routes/TreatmentDetail"));
@@ -108,6 +109,7 @@ const App = () => {
                 <Route path="/admin/columns" element={<AdminColumns />} />
                 <Route path="/admin/banners" element={<AdminBanners />} />
                 <Route path="/admin/hospital-profiles" element={<AdminHospitalProfiles />} />
+                <Route path="/admin/partner-accounts" element={<AdminPartnerAccounts />} />
                 <Route path="/who_we_are" element={<WhoWeAre />} />
                 <Route path="/treatments" element={<Treatments />} />
                 <Route path="/treatments/:id" element={<TreatmentDetail />} />

--- a/src/api/partner.ts
+++ b/src/api/partner.ts
@@ -1,0 +1,131 @@
+import { API_ROOT } from "./root";
+
+// Partner portal auth is separate from the doctor/site-admin session
+// (different token, its own localStorage key).
+const TOKEN_KEY = "partner_token";
+
+export function getPartnerToken(): string | null {
+  return localStorage.getItem(TOKEN_KEY);
+}
+export function setPartnerToken(token: string) {
+  localStorage.setItem(TOKEN_KEY, token);
+}
+export function clearPartnerToken() {
+  localStorage.removeItem(TOKEN_KEY);
+}
+
+export class PartnerError extends Error {
+  code: number;
+  constructor(code: number, message?: string) {
+    super(message);
+    this.code = code;
+  }
+}
+
+async function partnerFetch<T>(
+  path: string,
+  options: RequestInit = {},
+  body?: unknown,
+  auth = true,
+): Promise<T> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Accept: "application/json",
+  };
+  if (auth) {
+    const token = getPartnerToken();
+    if (!token) throw new PartnerError(401, "not logged in");
+    headers.Authorization = `Bearer ${token}`;
+  }
+  const res = await fetch(API_ROOT + path, {
+    ...options,
+    headers: { ...headers, ...(options.headers as Record<string, string>) },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) {
+    const b = await res.json().catch(() => ({}));
+    throw new PartnerError(res.status, b?.message);
+  }
+  return res.status === 204 ? (undefined as T) : res.json();
+}
+
+export type PartnerStatus = "pending" | "approved" | "rejected";
+
+export interface PartnerMe {
+  id: string;
+  email: string;
+  contactName: string;
+  hospitalName: string;
+  status: PartnerStatus;
+}
+
+export interface PartnerProfile {
+  id: string;
+  kakao_place_id: string;
+  name: string;
+  description: string | null;
+  banner_image_url: string | null;
+  images: string[];
+  phone: string | null;
+  address: string | null;
+  status: string;
+}
+
+export interface PartnerProfileInput {
+  kakao_place_id: string;
+  name: string;
+  description?: string;
+  banner_image_url?: string | null;
+  images?: string[];
+  phone?: string;
+  address?: string;
+}
+
+export function partnerSignup(data: {
+  email: string;
+  password: string;
+  contact_name: string;
+  hospital_name: string;
+}): Promise<{ id: string; status: PartnerStatus }> {
+  return partnerFetch("/partner/signup", { method: "POST" }, data, false);
+}
+
+export async function partnerLogin(email: string, password: string): Promise<PartnerStatus> {
+  const r = await partnerFetch<{ token: string; status: PartnerStatus }>(
+    "/partner/login",
+    { method: "POST" },
+    { email, password },
+    false,
+  );
+  setPartnerToken(r.token);
+  return r.status;
+}
+
+export function partnerMe(): Promise<PartnerMe> {
+  return partnerFetch("/partner/me");
+}
+
+export function getPartnerProfile(): Promise<PartnerProfile | null> {
+  return partnerFetch("/partner/profile");
+}
+
+export function savePartnerProfile(data: PartnerProfileInput): Promise<PartnerProfile> {
+  return partnerFetch("/partner/profile", { method: "PUT" }, data);
+}
+
+export async function uploadPartnerImage(file: File): Promise<{ url: string }> {
+  const token = getPartnerToken();
+  if (!token) throw new PartnerError(401, "not logged in");
+  const fd = new FormData();
+  fd.append("image", file);
+  const res = await fetch(API_ROOT + "/partner/profile/upload", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}` },
+    body: fd,
+  });
+  if (!res.ok) {
+    const b = await res.json().catch(() => ({}));
+    throw new PartnerError(res.status, b?.message);
+  }
+  return res.json();
+}

--- a/src/api/partnerAccount.ts
+++ b/src/api/partnerAccount.ts
@@ -10,6 +10,8 @@ export interface PartnerAccount {
   hospitalName: string;
   status: PartnerAccountStatus;
   createdAt: string;
+  claimedPlaceId: string | null;
+  claimedName: string | null;
 }
 
 export function listPartnerAccounts(): Promise<PartnerAccount[]> {

--- a/src/api/partnerAccount.ts
+++ b/src/api/partnerAccount.ts
@@ -1,0 +1,28 @@
+import { jsonFetchWithSession } from "../lib/fetch";
+import { API_ROOT } from "./root";
+
+export type PartnerAccountStatus = "pending" | "approved" | "rejected";
+
+export interface PartnerAccount {
+  id: string;
+  email: string;
+  contactName: string;
+  hospitalName: string;
+  status: PartnerAccountStatus;
+  createdAt: string;
+}
+
+export function listPartnerAccounts(): Promise<PartnerAccount[]> {
+  return jsonFetchWithSession(API_ROOT + "/partner/accounts");
+}
+
+export function setPartnerAccountStatus(
+  id: string,
+  status: PartnerAccountStatus,
+): Promise<{ id: string; status: PartnerAccountStatus }> {
+  return jsonFetchWithSession(
+    API_ROOT + "/partner/accounts/" + id,
+    { method: "PATCH" },
+    { status },
+  );
+}

--- a/src/routes/admin_myodoc.tsx
+++ b/src/routes/admin_myodoc.tsx
@@ -25,6 +25,9 @@ export default function AdminMyodoc() {
         <a href="/admin/hospital-profiles" style={linkRow}>
           병원 프로필 관리 →
         </a>
+        <a href="/admin/partner-accounts" style={linkRow}>
+          병원 파트너 계정 승인 →
+        </a>
       </div>
     </div>
   );

--- a/src/routes/admin_partner_accounts.tsx
+++ b/src/routes/admin_partner_accounts.tsx
@@ -1,0 +1,111 @@
+import { useContext, type CSSProperties } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { UserContext } from "../App";
+import { PrimaryButton, PrimaryNagativeButton } from "../components/button";
+import {
+  listPartnerAccounts,
+  setPartnerAccountStatus,
+  type PartnerAccountStatus,
+} from "../api/partnerAccount";
+
+export default function AdminPartnerAccounts() {
+  const { user } = useContext(UserContext);
+  const qc = useQueryClient();
+
+  const listQuery = useQuery({
+    queryKey: ["admin", "partnerAccounts"],
+    queryFn: listPartnerAccounts,
+  });
+
+  const statusMutation = useMutation({
+    mutationFn: ({ id, status }: { id: string; status: PartnerAccountStatus }) =>
+      setPartnerAccountStatus(id, status),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["admin", "partnerAccounts"] }),
+    onError: (e: any) => alert(e?.message ?? "변경 실패"),
+  });
+
+  if (!user?.is_site_admin) {
+    return <div style={{ padding: 24 }}>Not authorized</div>;
+  }
+
+  return (
+    <div style={{ padding: 24, maxWidth: 900, margin: "0 auto" }}>
+      <a href="/admin/myodoc" style={{ display: "inline-block", marginBottom: 12, color: "#6b7280" }}>
+        ← myodoc 관리
+      </a>
+      <h1>병원 파트너 계정 승인</h1>
+      <p style={{ color: "#6b7280", marginTop: -6 }}>
+        가입한 병원 계정을 승인하면 해당 병원 프로필이 앱에 노출됩니다.
+      </p>
+
+      {listQuery.isLoading ? (
+        <div>Loading…</div>
+      ) : (
+        <table style={{ width: "100%", borderCollapse: "collapse", marginTop: 12 }}>
+          <thead>
+            <tr>
+              <th style={th}>병원명</th>
+              <th style={th}>담당자</th>
+              <th style={th}>이메일</th>
+              <th style={th}>가입일</th>
+              <th style={th}>상태</th>
+              <th style={th} />
+            </tr>
+          </thead>
+          <tbody>
+            {listQuery.data?.map((a) => (
+              <tr key={a.id}>
+                <td style={td}>{a.hospitalName}</td>
+                <td style={td}>{a.contactName}</td>
+                <td style={td}>{a.email}</td>
+                <td style={td}>{a.createdAt.slice(0, 10)}</td>
+                <td style={td}>
+                  <span style={badge(a.status)}>{STATUS_LABEL[a.status]}</span>
+                </td>
+                <td style={{ ...td, whiteSpace: "nowrap" }}>
+                  {a.status !== "approved" && (
+                    <PrimaryButton
+                      onClick={() => statusMutation.mutate({ id: a.id, status: "approved" })}
+                    >
+                      승인
+                    </PrimaryButton>
+                  )}{" "}
+                  {a.status !== "rejected" && (
+                    <PrimaryNagativeButton
+                      onClick={() => statusMutation.mutate({ id: a.id, status: "rejected" })}
+                    >
+                      거절
+                    </PrimaryNagativeButton>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+const STATUS_LABEL: Record<PartnerAccountStatus, string> = {
+  pending: "승인 대기",
+  approved: "승인됨",
+  rejected: "거절됨",
+};
+
+function badge(status: PartnerAccountStatus): CSSProperties {
+  const color =
+    status === "approved" ? "#0d7d6f" : status === "rejected" ? "#b3261e" : "#a2610a";
+  return {
+    color,
+    background: color + "18",
+    borderRadius: 999,
+    padding: "2px 10px",
+    fontSize: 12,
+    fontWeight: 700,
+  };
+}
+
+const th: CSSProperties = { textAlign: "left", borderBottom: "2px solid #eee", padding: 8 };
+const td: CSSProperties = { borderBottom: "1px solid #eee", padding: 8 };

--- a/src/routes/admin_partner_accounts.tsx
+++ b/src/routes/admin_partner_accounts.tsx
@@ -37,6 +37,8 @@ export default function AdminPartnerAccounts() {
       <h1>병원 파트너 계정 승인</h1>
       <p style={{ color: "#6b7280", marginTop: -6 }}>
         가입한 병원 계정을 승인하면 해당 병원 프로필이 앱에 노출됩니다.
+        ⚠️ 승인 전, "신청 병원명"과 "claim한 병원"이 실제로 일치하는지 꼭
+        확인하세요 (아무 병원이나 claim 가능하므로 사칭 방지의 핵심 단계).
       </p>
 
       {listQuery.isLoading ? (
@@ -45,7 +47,8 @@ export default function AdminPartnerAccounts() {
         <table style={{ width: "100%", borderCollapse: "collapse", marginTop: 12 }}>
           <thead>
             <tr>
-              <th style={th}>병원명</th>
+              <th style={th}>신청 병원명</th>
+              <th style={th}>claim한 병원 (place id)</th>
               <th style={th}>담당자</th>
               <th style={th}>이메일</th>
               <th style={th}>가입일</th>
@@ -57,6 +60,17 @@ export default function AdminPartnerAccounts() {
             {listQuery.data?.map((a) => (
               <tr key={a.id}>
                 <td style={td}>{a.hospitalName}</td>
+                <td style={td}>
+                  {a.claimedName ? (
+                    <>
+                      {a.claimedName}
+                      <br />
+                      <span style={{ color: "#9ca3af", fontSize: 12 }}>{a.claimedPlaceId}</span>
+                    </>
+                  ) : (
+                    <span style={{ color: "#9ca3af" }}>미작성</span>
+                  )}
+                </td>
                 <td style={td}>{a.contactName}</td>
                 <td style={td}>{a.email}</td>
                 <td style={td}>{a.createdAt.slice(0, 10)}</td>

--- a/src/routes/partner/PartnerLogin.tsx
+++ b/src/routes/partner/PartnerLogin.tsx
@@ -1,0 +1,96 @@
+import { useState, type CSSProperties } from "react";
+import { useNavigate } from "react-router";
+
+import { partnerLogin } from "../../api/partner";
+
+export default function PartnerLogin() {
+  const nav = useNavigate();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const submit = async () => {
+    setError(null);
+    setBusy(true);
+    try {
+      await partnerLogin(email.trim(), password);
+      nav("/partner/profile");
+    } catch (e: any) {
+      setError(e?.message ?? "로그인 실패");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div style={wrap}>
+      <div style={card}>
+        <h1 style={{ marginTop: 0 }}>병원 파트너 로그인</h1>
+        <p style={{ color: "#6b7280", marginTop: -6 }}>myodoc 병원 프로필 관리</p>
+        <input
+          style={inp}
+          placeholder="이메일"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          style={inp}
+          type="password"
+          placeholder="비밀번호"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && submit()}
+        />
+        {error && <p style={{ color: "#b3261e", fontSize: 13 }}>{error}</p>}
+        <button style={btn} disabled={busy} onClick={submit}>
+          {busy ? "로그인 중…" : "로그인"}
+        </button>
+        <p style={{ fontSize: 13, textAlign: "center", marginBottom: 0 }}>
+          계정이 없으신가요?{" "}
+          <a href="/partner/signup" style={{ color: "#0d47a1" }}>
+            병원 가입
+          </a>
+        </p>
+      </div>
+    </div>
+  );
+}
+
+const wrap: CSSProperties = {
+  minHeight: "100vh",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  background: "#f6f7fb",
+  padding: 16,
+};
+const card: CSSProperties = {
+  width: "100%",
+  maxWidth: 380,
+  background: "#fff",
+  border: "1px solid #e5e7eb",
+  borderRadius: 12,
+  padding: 28,
+  display: "flex",
+  flexDirection: "column",
+  gap: 10,
+};
+const inp: CSSProperties = {
+  padding: 11,
+  border: "1px solid #ccc",
+  borderRadius: 8,
+  fontSize: 15,
+  boxSizing: "border-box",
+};
+const btn: CSSProperties = {
+  padding: 12,
+  border: "none",
+  borderRadius: 8,
+  background: "#0d47a1",
+  color: "#fff",
+  fontSize: 15,
+  fontWeight: 700,
+  cursor: "pointer",
+  marginTop: 4,
+};

--- a/src/routes/partner/PartnerProfile.tsx
+++ b/src/routes/partner/PartnerProfile.tsx
@@ -1,0 +1,273 @@
+import { useEffect, useState, type CSSProperties } from "react";
+import { useNavigate } from "react-router";
+
+import {
+  clearPartnerToken,
+  getPartnerProfile,
+  getPartnerToken,
+  partnerMe,
+  savePartnerProfile,
+  uploadPartnerImage,
+  type PartnerMe,
+  type PartnerProfileInput,
+} from "../../api/partner";
+
+const EMPTY: PartnerProfileInput = {
+  kakao_place_id: "",
+  name: "",
+  description: "",
+  banner_image_url: "",
+  images: [],
+  phone: "",
+  address: "",
+};
+
+export default function PartnerProfile() {
+  const nav = useNavigate();
+  const [me, setMe] = useState<PartnerMe | null>(null);
+  const [form, setForm] = useState<PartnerProfileInput>(EMPTY);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [msg, setMsg] = useState<string | null>(null);
+  const [bannerUploading, setBannerUploading] = useState(false);
+  const [galleryUploading, setGalleryUploading] = useState(false);
+
+  useEffect(() => {
+    if (!getPartnerToken()) {
+      nav("/partner/login");
+      return;
+    }
+    Promise.all([partnerMe(), getPartnerProfile()])
+      .then(([m, p]) => {
+        setMe(m);
+        if (p) {
+          setForm({
+            kakao_place_id: p.kakao_place_id,
+            name: p.name,
+            description: p.description ?? "",
+            banner_image_url: p.banner_image_url ?? "",
+            images: p.images ?? [],
+            phone: p.phone ?? "",
+            address: p.address ?? "",
+          });
+        } else {
+          setForm((f) => ({ ...f, name: m.hospitalName }));
+        }
+      })
+      .catch(() => {
+        clearPartnerToken();
+        nav("/partner/login");
+      })
+      .finally(() => setLoading(false));
+  }, [nav]);
+
+  const set = (k: keyof PartnerProfileInput) => (e: any) =>
+    setForm((f) => ({ ...f, [k]: e.target.value }));
+
+  const save = async () => {
+    setMsg(null);
+    setSaving(true);
+    try {
+      await savePartnerProfile(form);
+      setMsg("저장되었습니다.");
+    } catch (e: any) {
+      setMsg(e?.message ?? "저장 실패");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) return <div style={{ padding: 24 }}>Loading…</div>;
+
+  const canSave = !!form.kakao_place_id.trim() && !!form.name.trim();
+
+  return (
+    <div style={{ maxWidth: 720, margin: "0 auto", padding: 24 }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <h1 style={{ margin: 0 }}>병원 프로필 관리</h1>
+        <button
+          style={logout}
+          onClick={() => {
+            clearPartnerToken();
+            nav("/partner/login");
+          }}
+        >
+          로그아웃
+        </button>
+      </div>
+
+      {me && (
+        <div style={statusBox(me.status)}>
+          {me.status === "approved"
+            ? "승인됨 — 저장하면 앱에 바로 노출됩니다."
+            : me.status === "rejected"
+              ? "승인이 거절되었습니다. 관리자에게 문의해 주세요."
+              : "승인 대기 중 — 프로필을 미리 작성해 두면 승인 후 바로 노출됩니다."}
+        </div>
+      )}
+
+      <div style={card}>
+        <Field label="카카오 place id (앱 검색 결과의 내 병원 id)">
+          <input value={form.kakao_place_id} onChange={set("kakao_place_id")} style={inp} />
+        </Field>
+        <Field label="병원명">
+          <input value={form.name} onChange={set("name")} style={inp} />
+        </Field>
+        <Field label="상세설명">
+          <textarea value={form.description} onChange={set("description")} style={{ ...inp, height: 160 }} />
+        </Field>
+
+        <Field label="배너 이미지">
+          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+            <input value={form.banner_image_url ?? ""} onChange={set("banner_image_url")} style={{ ...inp, flex: 1 }} placeholder="파일 업로드 또는 URL" />
+            <UploadBtn
+              busy={bannerUploading}
+              onFile={async (f) => {
+                setBannerUploading(true);
+                try {
+                  const { url } = await uploadPartnerImage(f);
+                  setForm((s) => ({ ...s, banner_image_url: url }));
+                } catch (e: any) {
+                  alert(e?.message ?? "업로드 실패");
+                } finally {
+                  setBannerUploading(false);
+                }
+              }}
+            />
+          </div>
+          {form.banner_image_url ? <img src={form.banner_image_url} alt="" style={thumb} /> : null}
+        </Field>
+
+        <Field label="상세 이미지 (여러 장)">
+          <UploadBtn
+            busy={galleryUploading}
+            onFile={async (f) => {
+              setGalleryUploading(true);
+              try {
+                const { url } = await uploadPartnerImage(f);
+                setForm((s) => ({ ...s, images: [...(s.images ?? []), url] }));
+              } catch (e: any) {
+                alert(e?.message ?? "업로드 실패");
+              } finally {
+                setGalleryUploading(false);
+              }
+            }}
+          />
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 8, marginTop: 8 }}>
+            {(form.images ?? []).map((url, i) => (
+              <div key={i} style={{ position: "relative" }}>
+                <img src={url} alt="" style={{ ...thumb, marginTop: 0 }} />
+                <button
+                  type="button"
+                  style={removeBtn}
+                  onClick={() => setForm((s) => ({ ...s, images: (s.images ?? []).filter((_, idx) => idx !== i) }))}
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+          </div>
+        </Field>
+
+        <div style={{ display: "flex", gap: 12 }}>
+          <Field label="전화">
+            <input value={form.phone} onChange={set("phone")} style={inp} />
+          </Field>
+          <Field label="주소">
+            <input value={form.address} onChange={set("address")} style={inp} />
+          </Field>
+        </div>
+
+        {msg && <p style={{ fontSize: 13, color: msg.includes("저장되") ? "#0d7d6f" : "#b3261e" }}>{msg}</p>}
+        <button style={{ ...saveBtn, opacity: canSave && !saving ? 1 : 0.5 }} disabled={!canSave || saving} onClick={save}>
+          {saving ? "저장 중…" : "저장"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function UploadBtn({ busy, onFile }: { busy: boolean; onFile: (f: File) => void }) {
+  return (
+    <label style={{ ...uploadBtn, opacity: busy ? 0.6 : 1, pointerEvents: busy ? "none" : "auto" }}>
+      {busy ? "업로드 중…" : "파일 선택"}
+      <input
+        type="file"
+        accept="image/*"
+        style={{ display: "none" }}
+        onChange={(e) => {
+          const f = e.target.files?.[0];
+          if (f) onFile(f);
+          e.target.value = "";
+        }}
+      />
+    </label>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div style={{ marginBottom: 10, flex: 1 }}>
+      <label style={{ display: "block", fontSize: 13, color: "#555", marginBottom: 4 }}>{label}</label>
+      {children}
+    </div>
+  );
+}
+
+function statusBox(status: string): CSSProperties {
+  const color = status === "approved" ? "#0d7d6f" : status === "rejected" ? "#b3261e" : "#a2610a";
+  return {
+    background: color + "14",
+    color,
+    borderRadius: 8,
+    padding: "10px 14px",
+    fontSize: 13,
+    fontWeight: 600,
+    margin: "16px 0 4px",
+  };
+}
+
+const card: CSSProperties = { border: "1px solid #ddd", borderRadius: 8, padding: 16, marginTop: 12 };
+const inp: CSSProperties = { width: "100%", padding: 8, border: "1px solid #ccc", borderRadius: 6, boxSizing: "border-box" };
+const uploadBtn: CSSProperties = {
+  flexShrink: 0,
+  padding: "8px 14px",
+  border: "1px solid #ccc",
+  borderRadius: 6,
+  background: "#f3f4f6",
+  cursor: "pointer",
+  fontSize: 13,
+  whiteSpace: "nowrap",
+};
+const thumb: CSSProperties = { marginTop: 8, maxWidth: 200, maxHeight: 120, borderRadius: 8, display: "block" };
+const removeBtn: CSSProperties = {
+  position: "absolute",
+  top: 2,
+  right: 2,
+  width: 22,
+  height: 22,
+  borderRadius: 11,
+  border: "none",
+  background: "rgba(0,0,0,0.6)",
+  color: "#fff",
+  cursor: "pointer",
+};
+const saveBtn: CSSProperties = {
+  padding: "12px 20px",
+  border: "none",
+  borderRadius: 8,
+  background: "#0d47a1",
+  color: "#fff",
+  fontSize: 15,
+  fontWeight: 700,
+  cursor: "pointer",
+  marginTop: 8,
+};
+const logout: CSSProperties = {
+  padding: "6px 12px",
+  border: "1px solid #ddd",
+  borderRadius: 8,
+  background: "#fff",
+  cursor: "pointer",
+  fontSize: 13,
+};

--- a/src/routes/partner/PartnerSignup.tsx
+++ b/src/routes/partner/PartnerSignup.tsx
@@ -1,0 +1,127 @@
+import { useState, type CSSProperties } from "react";
+import { useNavigate } from "react-router";
+
+import { partnerSignup } from "../../api/partner";
+
+export default function PartnerSignup() {
+  const nav = useNavigate();
+  const [form, setForm] = useState({
+    hospital_name: "",
+    contact_name: "",
+    email: "",
+    password: "",
+  });
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [done, setDone] = useState(false);
+
+  const set = (k: keyof typeof form) => (e: any) =>
+    setForm((f) => ({ ...f, [k]: e.target.value }));
+
+  const canSubmit =
+    form.hospital_name.trim() &&
+    form.contact_name.trim() &&
+    form.email.trim() &&
+    form.password.length >= 8;
+
+  const submit = async () => {
+    setError(null);
+    setBusy(true);
+    try {
+      await partnerSignup({
+        email: form.email.trim(),
+        password: form.password,
+        contact_name: form.contact_name.trim(),
+        hospital_name: form.hospital_name.trim(),
+      });
+      setDone(true);
+    } catch (e: any) {
+      setError(e?.message ?? "가입 실패");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (done) {
+    return (
+      <div style={wrap}>
+        <div style={card}>
+          <h1 style={{ marginTop: 0 }}>가입 신청 완료</h1>
+          <p style={{ color: "#374151" }}>
+            관리자 승인 후 병원 프로필이 앱에 노출됩니다. 승인 전에도 로그인해서
+            프로필을 미리 작성해 둘 수 있어요.
+          </p>
+          <button style={btn} onClick={() => nav("/partner/login")}>
+            로그인하러 가기
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={wrap}>
+      <div style={card}>
+        <h1 style={{ marginTop: 0 }}>병원 파트너 가입</h1>
+        <input style={inp} placeholder="병원명" value={form.hospital_name} onChange={set("hospital_name")} />
+        <input style={inp} placeholder="담당자 이름" value={form.contact_name} onChange={set("contact_name")} />
+        <input style={inp} placeholder="이메일" value={form.email} onChange={set("email")} />
+        <input
+          style={inp}
+          type="password"
+          placeholder="비밀번호 (8자 이상)"
+          value={form.password}
+          onChange={set("password")}
+        />
+        {error && <p style={{ color: "#b3261e", fontSize: 13 }}>{error}</p>}
+        <button style={{ ...btn, opacity: canSubmit && !busy ? 1 : 0.5 }} disabled={!canSubmit || busy} onClick={submit}>
+          {busy ? "가입 중…" : "가입 신청"}
+        </button>
+        <p style={{ fontSize: 13, textAlign: "center", marginBottom: 0 }}>
+          이미 계정이 있으신가요?{" "}
+          <a href="/partner/login" style={{ color: "#0d47a1" }}>
+            로그인
+          </a>
+        </p>
+      </div>
+    </div>
+  );
+}
+
+const wrap: CSSProperties = {
+  minHeight: "100vh",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  background: "#f6f7fb",
+  padding: 16,
+};
+const card: CSSProperties = {
+  width: "100%",
+  maxWidth: 380,
+  background: "#fff",
+  border: "1px solid #e5e7eb",
+  borderRadius: 12,
+  padding: 28,
+  display: "flex",
+  flexDirection: "column",
+  gap: 10,
+};
+const inp: CSSProperties = {
+  padding: 11,
+  border: "1px solid #ccc",
+  borderRadius: 8,
+  fontSize: 15,
+  boxSizing: "border-box",
+};
+const btn: CSSProperties = {
+  padding: 12,
+  border: "none",
+  borderRadius: 8,
+  background: "#0d47a1",
+  color: "#fff",
+  fontSize: 15,
+  fontWeight: 700,
+  cursor: "pointer",
+  marginTop: 4,
+};


### PR DESCRIPTION
## 요약
Phase 2 myopia 프론트 — 병원 파트너 승인(어드민) + 파트너 포털(병원 셀프).

**어드민 (사이트관리자)**
- `/admin/partner-accounts` — 파트너 계정 승인/거절, 승인 시 프로필 published

**파트너 포털 (병원, 별도 섹션)**
- `/partner/signup` 가입 → `/partner/login` 로그인 → `/partner/profile` 프로필 관리
- 의사/어드민 앱과 분리 (공유 헤더 없음, 별도 토큰/레이아웃)
- 프로필: 카카오 place id + 배너/상세설명/이미지 + 전화/주소, 이미지 업로드
- 승인 상태 안내 (대기 중엔 저장만, 승인되면 앱 노출)

## 의존성
- myopiaBackend PR #29 (`/partner/*`, `/partner/accounts`)

## 배포
- 기존 eye 앱에 포함 (새 인프라 없음, `/partner` 경로만 추가)

## 테스트
- [ ] /partner/signup 가입 → /partner/login 로그인 → 프로필 저장
- [ ] 어드민에서 승인 → 앱 병원 상세에 노출
- [ ] 로그아웃/미로그인 시 /partner/profile 접근하면 로그인으로