### PR TITLE
feat(admin/partner): 모두닥 카드 입력 + 리뷰 관리 UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,7 @@ const AdminMyodoc = lazy(() => import("./routes/admin_myodoc"));
 const AdminColumns = lazy(() => import("./routes/admin_columns"));
 const AdminBanners = lazy(() => import("./routes/admin_banners"));
 const AdminHospitalProfiles = lazy(() => import("./routes/admin_hospital_profiles"));
+const AdminHospitalReviews = lazy(() => import("./routes/admin_hospital_reviews"));
 const AdminPartnerAccounts = lazy(() => import("./routes/admin_partner_accounts"));
 const PartnerLogin = lazy(() => import("./routes/partner/PartnerLogin"));
 const PartnerSignup = lazy(() => import("./routes/partner/PartnerSignup"));
@@ -112,6 +113,7 @@ const App = () => {
                 <Route path="/admin/columns" element={<AdminColumns />} />
                 <Route path="/admin/banners" element={<AdminBanners />} />
                 <Route path="/admin/hospital-profiles" element={<AdminHospitalProfiles />} />
+                <Route path="/admin/hospital-profiles/:placeId/reviews" element={<AdminHospitalReviews />} />
                 <Route path="/admin/partner-accounts" element={<AdminPartnerAccounts />} />
                 <Route path="/who_we_are" element={<WhoWeAre />} />
                 <Route path="/treatments" element={<Treatments />} />

--- a/src/api/hospitalProfile.ts
+++ b/src/api/hospitalProfile.ts
@@ -1,5 +1,6 @@
 import { AuthorizationError, HttpError, jsonFetchWithSession } from "../lib/fetch";
 import { API_ROOT } from "./root";
+import type { TreatmentItem } from "../constants/treatmentCategories";
 
 export type HospitalProfileStatus = "draft" | "pending" | "published";
 
@@ -13,6 +14,12 @@ export interface HospitalProfile {
   phone: string | null;
   address: string | null;
   status: HospitalProfileStatus;
+  hospital_id: string | null;
+  thumbnail_url: string | null;
+  keywords: string[];
+  treatment_items: TreatmentItem[] | null;
+  verified: boolean;
+  booking_url: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -26,6 +33,42 @@ export interface HospitalProfileInput {
   phone?: string;
   address?: string;
   status?: HospitalProfileStatus;
+  hospital_id?: string | null;
+  thumbnail_url?: string | null;
+  keywords?: string[];
+  treatment_items?: TreatmentItem[];
+  verified?: boolean;
+  booking_url?: string | null;
+}
+
+export interface HospitalReview {
+  id: string;
+  kakao_place_id: string;
+  user_id: string;
+  hospital_id: string;
+  rating: number;
+  content: string;
+  images: string[];
+  status: "visible" | "hidden";
+  created_at: string;
+  updated_at: string;
+}
+
+export function listHospitalReviews(kakaoPlaceId: string): Promise<HospitalReview[]> {
+  return jsonFetchWithSession(
+    API_ROOT + "/hospital-profile/moderation/" + encodeURIComponent(kakaoPlaceId) + "/reviews",
+  );
+}
+
+export function setReviewStatus(
+  id: string,
+  status: "visible" | "hidden",
+): Promise<{ id: string; status: string }> {
+  return jsonFetchWithSession(
+    API_ROOT + "/hospital-profile/moderation/reviews/" + id,
+    { method: "PATCH" },
+    { status },
+  );
 }
 
 export function listHospitalProfiles(): Promise<HospitalProfile[]> {

--- a/src/api/partner.ts
+++ b/src/api/partner.ts
@@ -1,4 +1,5 @@
 import { API_ROOT } from "./root";
+import type { TreatmentItem } from "../constants/treatmentCategories";
 
 // Partner portal auth is separate from the doctor/site-admin session
 // (different token, its own localStorage key).
@@ -68,6 +69,10 @@ export interface PartnerProfile {
   images: string[];
   phone: string | null;
   address: string | null;
+  thumbnail_url: string | null;
+  keywords: string[];
+  treatment_items: TreatmentItem[] | null;
+  booking_url: string | null;
   status: string;
 }
 
@@ -79,6 +84,10 @@ export interface PartnerProfileInput {
   images?: string[];
   phone?: string;
   address?: string;
+  thumbnail_url?: string | null;
+  keywords?: string[];
+  treatment_items?: TreatmentItem[];
+  booking_url?: string | null;
 }
 
 export function partnerSignup(data: {

--- a/src/components/hospitalCardEditors.tsx
+++ b/src/components/hospitalCardEditors.tsx
@@ -1,0 +1,189 @@
+import { useState, type CSSProperties } from "react";
+
+import {
+  TREATMENT_CATEGORIES,
+  type TreatmentItem,
+} from "../constants/treatmentCategories";
+
+/* ---- keyword tags ------------------------------------------------------ */
+
+export function KeywordsEditor({
+  value,
+  onChange,
+}: {
+  value: string[];
+  onChange: (next: string[]) => void;
+}) {
+  const [draft, setDraft] = useState("");
+
+  function add() {
+    const v = draft.trim();
+    if (!v || value.includes(v)) {
+      setDraft("");
+      return;
+    }
+    onChange([...value, v]);
+    setDraft("");
+  }
+
+  return (
+    <div>
+      <div style={{ display: "flex", gap: 8 }}>
+        <input
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              add();
+            }
+          }}
+          placeholder="예: 스마일라식, 드림렌즈 (Enter로 추가)"
+          style={inp}
+        />
+        <button type="button" onClick={add} style={smallBtn}>
+          추가
+        </button>
+      </div>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 8 }}>
+        {value.map((k) => (
+          <span key={k} style={tag}>
+            {k}
+            <button
+              type="button"
+              onClick={() => onChange(value.filter((x) => x !== k))}
+              style={tagX}
+            >
+              ×
+            </button>
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* ---- treatment items --------------------------------------------------- */
+
+export function TreatmentItemsEditor({
+  value,
+  onChange,
+}: {
+  value: TreatmentItem[];
+  onChange: (next: TreatmentItem[]) => void;
+}) {
+  function update(i: number, patch: Partial<TreatmentItem>) {
+    onChange(value.map((it, idx) => (idx === i ? { ...it, ...patch } : it)));
+  }
+  function addItem() {
+    onChange([...value, { category: "dreamLens", name: "" }]);
+  }
+  function num(v: string): number | null {
+    const n = Number(v.replace(/[^0-9]/g, ""));
+    return Number.isFinite(n) && v.trim() !== "" ? n : null;
+  }
+
+  return (
+    <div>
+      {value.map((it, i) => (
+        <div key={i} style={itemCard}>
+          <div style={{ display: "flex", gap: 8, marginBottom: 8 }}>
+            <select
+              value={it.category}
+              onChange={(e) => update(i, { category: e.target.value })}
+              style={{ ...inp, flex: "0 0 160px" }}
+            >
+              {TREATMENT_CATEGORIES.map((c) => (
+                <option key={c.key} value={c.key}>
+                  {c.label}
+                </option>
+              ))}
+            </select>
+            <input
+              value={it.name}
+              onChange={(e) => update(i, { name: e.target.value })}
+              placeholder="항목명 (예: 노안수술 검진)"
+              style={{ ...inp, flex: 1 }}
+            />
+            <button
+              type="button"
+              onClick={() => onChange(value.filter((_, idx) => idx !== i))}
+              style={smallBtnDanger}
+            >
+              삭제
+            </button>
+          </div>
+          <div style={{ display: "flex", gap: 8, marginBottom: 8 }}>
+            <input
+              value={it.normalPrice ?? ""}
+              onChange={(e) => update(i, { normalPrice: num(e.target.value) })}
+              placeholder="정상가 (원)"
+              inputMode="numeric"
+              style={{ ...inp, flex: 1 }}
+            />
+            <input
+              value={it.eventPrice ?? ""}
+              onChange={(e) => update(i, { eventPrice: num(e.target.value) })}
+              placeholder="이벤트가 (원, 선택)"
+              inputMode="numeric"
+              style={{ ...inp, flex: 1 }}
+            />
+          </div>
+          <textarea
+            value={it.description ?? ""}
+            onChange={(e) => update(i, { description: e.target.value })}
+            placeholder="안내 문구 (예: 검진항목 등에 따라 비용이 상이할 수 있습니다)"
+            style={{ ...inp, height: 60 }}
+          />
+        </div>
+      ))}
+      <button type="button" onClick={addItem} style={smallBtn}>
+        + 치료항목 추가
+      </button>
+    </div>
+  );
+}
+
+const inp: CSSProperties = {
+  width: "100%",
+  padding: 8,
+  border: "1px solid #ccc",
+  borderRadius: 6,
+  boxSizing: "border-box",
+};
+const smallBtn: CSSProperties = {
+  flexShrink: 0,
+  padding: "8px 14px",
+  border: "1px solid #ccc",
+  borderRadius: 6,
+  background: "#f3f4f6",
+  cursor: "pointer",
+  fontSize: 13,
+  whiteSpace: "nowrap",
+};
+const smallBtnDanger: CSSProperties = { ...smallBtn, color: "#b3261e", borderColor: "#f0c9c6" };
+const tag: CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  gap: 4,
+  background: "#eef2ff",
+  color: "#3730a3",
+  borderRadius: 999,
+  padding: "3px 6px 3px 10px",
+  fontSize: 13,
+};
+const tagX: CSSProperties = {
+  border: "none",
+  background: "transparent",
+  cursor: "pointer",
+  color: "#3730a3",
+  fontSize: 15,
+  lineHeight: 1,
+};
+const itemCard: CSSProperties = {
+  border: "1px solid #e5e7eb",
+  borderRadius: 8,
+  padding: 12,
+  marginBottom: 10,
+  background: "#fafafa",
+};

--- a/src/constants/treatmentCategories.ts
+++ b/src/constants/treatmentCategories.ts
@@ -1,0 +1,28 @@
+// Treatment-finder categories, kept in sync with the myodoc app
+// (src/features/treatmentFinder/TreatmentCategoryScreen.tsx). A profile's
+// treatment_items are tagged with one of these keys so the app can surface the
+// right item when a user browses by category.
+export const TREATMENT_CATEGORIES = [
+  { key: "visionCorrection", label: "시력교정술" },
+  { key: "presbyopia", label: "노안수술" },
+  { key: "cataract", label: "백내장수술" },
+  { key: "dreamLens", label: "드림렌즈" },
+  { key: "dryEyeIpl", label: "안구건조증 IPL" },
+  { key: "eyelid", label: "아이링수술" },
+  { key: "retina", label: "망막질환" },
+  { key: "etc", label: "기타" },
+] as const;
+
+export type TreatmentCategoryKey = (typeof TREATMENT_CATEGORIES)[number]["key"];
+
+export function categoryLabel(key: string): string {
+  return TREATMENT_CATEGORIES.find((c) => c.key === key)?.label ?? key;
+}
+
+export interface TreatmentItem {
+  category: string;
+  name: string;
+  normalPrice?: number | null;
+  eventPrice?: number | null;
+  description?: string;
+}

--- a/src/routes/admin_hospital_profiles.tsx
+++ b/src/routes/admin_hospital_profiles.tsx
@@ -13,6 +13,24 @@ import {
   type HospitalProfileInput,
 } from "../api/hospitalProfile";
 
+const MYODOC_WEB = "https://myodoc.co.kr";
+
+// Live detail page on the myodoc web app. The profile (banner/설명/이미지) is
+// fetched there by kakao place id; the rest are basic-info params the results
+// list normally passes, so we fill what we have.
+function previewUrl(placeId: string, name: string, phone?: string, address?: string) {
+  const q = new URLSearchParams({
+    id: placeId,
+    name: name ?? "",
+    category: "clinic",
+    address: address ?? "",
+    roadAddress: "",
+    phone: phone ?? "",
+    placeUrl: "",
+  });
+  return `${MYODOC_WEB}/treatment-finder/hospital?${q.toString()}`;
+}
+
 const EMPTY: HospitalProfileInput = {
   kakao_place_id: "",
   name: "",
@@ -171,11 +189,22 @@ export default function AdminHospitalProfiles() {
           </Field>
         </div>
 
-        <div style={{ display: "flex", gap: 8, marginTop: 8 }}>
+        <div style={{ display: "flex", gap: 8, marginTop: 8, alignItems: "center" }}>
           <PrimaryButton onClick={() => canSave && saveMutation.mutate()}>
             {editingId ? "수정 저장" : "생성"}
           </PrimaryButton>
           {editingId && <PrimaryNagativeButton onClick={reset}>취소</PrimaryNagativeButton>}
+          {canSave && (
+            <a
+              href={previewUrl(form.kakao_place_id, form.name, form.phone, form.address)}
+              target="_blank"
+              rel="noreferrer"
+              style={previewBtn}
+              title="저장 후 눌러야 최신 내용이 보입니다"
+            >
+              실서비스 미리보기 ↗
+            </a>
+          )}
         </div>
       </div>
 
@@ -199,6 +228,14 @@ export default function AdminHospitalProfiles() {
                 <td style={td}>{h.kakao_place_id}</td>
                 <td style={td}>{h.status}</td>
                 <td style={{ ...td, whiteSpace: "nowrap" }}>
+                  <a
+                    href={previewUrl(h.kakao_place_id, h.name, h.phone ?? undefined, h.address ?? undefined)}
+                    target="_blank"
+                    rel="noreferrer"
+                    style={previewBtn}
+                  >
+                    미리보기 ↗
+                  </a>{" "}
                   <PrimaryButton onClick={() => startEdit(h)}>수정</PrimaryButton>{" "}
                   <PrimaryNagativeButton
                     onClick={() => {
@@ -289,6 +326,18 @@ const removeBtn: CSSProperties = {
   color: "#fff",
   cursor: "pointer",
   lineHeight: "20px",
+};
+const previewBtn: CSSProperties = {
+  display: "inline-block",
+  padding: "8px 14px",
+  border: "1px solid #0d7d6f",
+  borderRadius: 6,
+  color: "#0d7d6f",
+  background: "#0d7d6f14",
+  textDecoration: "none",
+  fontSize: 13,
+  fontWeight: 600,
+  whiteSpace: "nowrap",
 };
 const th: CSSProperties = { textAlign: "left", borderBottom: "2px solid #eee", padding: 8 };
 const td: CSSProperties = { borderBottom: "1px solid #eee", padding: 8 };

--- a/src/routes/admin_hospital_profiles.tsx
+++ b/src/routes/admin_hospital_profiles.tsx
@@ -12,6 +12,13 @@ import {
   type HospitalProfile,
   type HospitalProfileInput,
 } from "../api/hospitalProfile";
+import { getHospitalList } from "../api/hospital";
+import { KeywordsEditor, TreatmentItemsEditor } from "../components/hospitalCardEditors";
+
+interface HospitalListItem {
+  id: string;
+  name: string;
+}
 
 const MYODOC_WEB = "https://myodoc.co.kr";
 
@@ -40,6 +47,12 @@ const EMPTY: HospitalProfileInput = {
   phone: "",
   address: "",
   status: "published",
+  hospital_id: null,
+  thumbnail_url: "",
+  keywords: [],
+  treatment_items: [],
+  verified: false,
+  booking_url: "",
 };
 
 export default function AdminHospitalProfiles() {
@@ -51,6 +64,12 @@ export default function AdminHospitalProfiles() {
   const listQuery = useQuery({
     queryKey: ["admin", "hospitalProfiles"],
     queryFn: listHospitalProfiles,
+  });
+
+  // Internal participating hospitals — linking one enables patient reviews.
+  const hospitalsQuery = useQuery<HospitalListItem[]>({
+    queryKey: ["hospitalList"],
+    queryFn: getHospitalList,
   });
 
   const saveMutation = useMutation({
@@ -81,6 +100,12 @@ export default function AdminHospitalProfiles() {
     onError: (e: any) => alert(e?.message ?? "업로드 실패"),
   });
 
+  const thumbUpload = useMutation({
+    mutationFn: (file: File) => uploadHospitalImage(file),
+    onSuccess: ({ url }) => setForm((f) => ({ ...f, thumbnail_url: url })),
+    onError: (e: any) => alert(e?.message ?? "업로드 실패"),
+  });
+
   function reset() {
     setEditingId(null);
     setForm(EMPTY);
@@ -97,6 +122,12 @@ export default function AdminHospitalProfiles() {
       phone: h.phone ?? "",
       address: h.address ?? "",
       status: h.status,
+      hospital_id: h.hospital_id ?? null,
+      thumbnail_url: h.thumbnail_url ?? "",
+      keywords: h.keywords ?? [],
+      treatment_items: h.treatment_items ?? [],
+      verified: h.verified ?? false,
+      booking_url: h.booking_url ?? "",
     });
   }
 
@@ -173,6 +204,64 @@ export default function AdminHospitalProfiles() {
           </div>
         </Field>
 
+        <Field label="썸네일 이미지 (리스트 카드용)">
+          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+            <input
+              value={form.thumbnail_url ?? ""}
+              onChange={set("thumbnail_url")}
+              style={{ ...inp, flex: 1 }}
+              placeholder="파일 업로드 또는 URL"
+            />
+            <UploadButton pending={thumbUpload.isPending} onFile={(f) => thumbUpload.mutate(f)} />
+          </div>
+          {form.thumbnail_url ? <img src={form.thumbnail_url} alt="" style={thumb} /> : null}
+        </Field>
+
+        <Field label="키워드 태그 (리스트 카드에 노출)">
+          <KeywordsEditor
+            value={form.keywords ?? []}
+            onChange={(keywords) => setForm((f) => ({ ...f, keywords }))}
+          />
+        </Field>
+
+        <Field label="치료항목 (카테고리별 가격·안내)">
+          <TreatmentItemsEditor
+            value={form.treatment_items ?? []}
+            onChange={(treatment_items) => setForm((f) => ({ ...f, treatment_items }))}
+          />
+        </Field>
+
+        <Field label="예약 링크 (선택)">
+          <input value={form.booking_url ?? ""} onChange={set("booking_url")} style={inp} placeholder="https://" />
+        </Field>
+
+        <div style={{ display: "flex", gap: 12 }}>
+          <Field label="내부 병원 연결 (리뷰 자격 판정)">
+            <select
+              value={form.hospital_id ?? ""}
+              onChange={(e) => setForm((f) => ({ ...f, hospital_id: e.target.value || null }))}
+              style={inp}
+            >
+              <option value="">연결 안 함 (리뷰 비활성)</option>
+              {hospitalsQuery.data?.map((h) => (
+                <option key={h.id} value={h.id}>
+                  {h.name}
+                </option>
+              ))}
+            </select>
+          </Field>
+          <Field label="인증 배지">
+            <label style={{ display: "flex", alignItems: "center", gap: 6, padding: "8px 0" }}>
+              <input
+                type="checkbox"
+                checked={!!form.verified}
+                onChange={(e) => setForm((f) => ({ ...f, verified: e.target.checked }))}
+              />
+              인증됨 표시
+            </label>
+          </Field>
+        </div>
+
         <div style={{ display: "flex", gap: 12 }}>
           <Field label="전화">
             <input value={form.phone} onChange={set("phone")} style={inp} />
@@ -235,6 +324,12 @@ export default function AdminHospitalProfiles() {
                     style={previewBtn}
                   >
                     미리보기 ↗
+                  </a>{" "}
+                  <a
+                    href={`/admin/hospital-profiles/${encodeURIComponent(h.kakao_place_id)}/reviews`}
+                    style={previewBtn}
+                  >
+                    리뷰 관리
                   </a>{" "}
                   <PrimaryButton onClick={() => startEdit(h)}>수정</PrimaryButton>{" "}
                   <PrimaryNagativeButton

--- a/src/routes/admin_hospital_reviews.tsx
+++ b/src/routes/admin_hospital_reviews.tsx
@@ -1,0 +1,98 @@
+import { useContext, type CSSProperties } from "react";
+import { useParams } from "react-router";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { UserContext } from "../App";
+import { PrimaryButton, PrimaryNagativeButton } from "../components/button";
+import {
+  listHospitalReviews,
+  setReviewStatus,
+  type HospitalReview,
+} from "../api/hospitalProfile";
+
+export default function AdminHospitalReviews() {
+  const { user } = useContext(UserContext);
+  const { placeId = "" } = useParams();
+  const qc = useQueryClient();
+
+  const reviewsQuery = useQuery({
+    queryKey: ["admin", "hospitalReviews", placeId],
+    queryFn: () => listHospitalReviews(placeId),
+    enabled: !!placeId,
+  });
+
+  const statusMutation = useMutation({
+    mutationFn: ({ id, status }: { id: string; status: "visible" | "hidden" }) =>
+      setReviewStatus(id, status),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: ["admin", "hospitalReviews", placeId] }),
+    onError: (e: any) => alert(e?.message ?? "변경 실패"),
+  });
+
+  if (!user?.is_site_admin) {
+    return <div style={{ padding: 24 }}>Not authorized</div>;
+  }
+
+  return (
+    <div style={{ padding: 24, maxWidth: 800, margin: "0 auto" }}>
+      <a
+        href="/admin/hospital-profiles"
+        style={{ display: "inline-block", marginBottom: 12, color: "#6b7280" }}
+      >
+        ← 병원 프로필 관리
+      </a>
+      <h1>리뷰 관리</h1>
+      <p style={{ color: "#6b7280", marginTop: -6 }}>
+        place id: {placeId}. 신고되거나 부적절한 리뷰를 숨길 수 있습니다.
+      </p>
+
+      {reviewsQuery.isLoading ? (
+        <div>Loading…</div>
+      ) : reviewsQuery.data && reviewsQuery.data.length > 0 ? (
+        reviewsQuery.data.map((r: HospitalReview) => (
+          <div key={r.id} style={{ ...reviewCard, opacity: r.status === "hidden" ? 0.5 : 1 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+              <strong>{"★".repeat(r.rating)}{"☆".repeat(5 - r.rating)}</strong>
+              <span style={{ color: "#9ca3af", fontSize: 12 }}>
+                {r.created_at.slice(0, 10)} · {r.status === "hidden" ? "숨김" : "노출"}
+              </span>
+            </div>
+            <p style={{ margin: "8px 0", whiteSpace: "pre-wrap" }}>{r.content}</p>
+            {r.images.length > 0 && (
+              <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                {r.images.map((url, i) => (
+                  <img key={i} src={url} alt="" style={img} />
+                ))}
+              </div>
+            )}
+            <div style={{ marginTop: 8 }}>
+              {r.status === "visible" ? (
+                <PrimaryNagativeButton
+                  onClick={() => statusMutation.mutate({ id: r.id, status: "hidden" })}
+                >
+                  숨기기
+                </PrimaryNagativeButton>
+              ) : (
+                <PrimaryButton
+                  onClick={() => statusMutation.mutate({ id: r.id, status: "visible" })}
+                >
+                  다시 노출
+                </PrimaryButton>
+              )}
+            </div>
+          </div>
+        ))
+      ) : (
+        <div style={{ color: "#9ca3af", marginTop: 16 }}>아직 리뷰가 없습니다.</div>
+      )}
+    </div>
+  );
+}
+
+const reviewCard: CSSProperties = {
+  border: "1px solid #e5e7eb",
+  borderRadius: 8,
+  padding: 16,
+  marginTop: 12,
+};
+const img: CSSProperties = { maxWidth: 120, maxHeight: 120, borderRadius: 6 };

--- a/src/routes/partner/PartnerProfile.tsx
+++ b/src/routes/partner/PartnerProfile.tsx
@@ -11,6 +11,7 @@ import {
   type PartnerMe,
   type PartnerProfileInput,
 } from "../../api/partner";
+import { KeywordsEditor, TreatmentItemsEditor } from "../../components/hospitalCardEditors";
 
 const EMPTY: PartnerProfileInput = {
   kakao_place_id: "",
@@ -20,6 +21,10 @@ const EMPTY: PartnerProfileInput = {
   images: [],
   phone: "",
   address: "",
+  thumbnail_url: "",
+  keywords: [],
+  treatment_items: [],
+  booking_url: "",
 };
 
 export default function PartnerProfile() {
@@ -31,6 +36,7 @@ export default function PartnerProfile() {
   const [msg, setMsg] = useState<string | null>(null);
   const [bannerUploading, setBannerUploading] = useState(false);
   const [galleryUploading, setGalleryUploading] = useState(false);
+  const [thumbUploading, setThumbUploading] = useState(false);
 
   useEffect(() => {
     if (!getPartnerToken()) {
@@ -49,6 +55,10 @@ export default function PartnerProfile() {
             images: p.images ?? [],
             phone: p.phone ?? "",
             address: p.address ?? "",
+            thumbnail_url: p.thumbnail_url ?? "",
+            keywords: p.keywords ?? [],
+            treatment_items: p.treatment_items ?? [],
+            booking_url: p.booking_url ?? "",
           });
         } else {
           setForm((f) => ({ ...f, name: m.hospitalName }));
@@ -167,6 +177,45 @@ export default function PartnerProfile() {
               </div>
             ))}
           </div>
+        </Field>
+
+        <Field label="썸네일 이미지 (리스트 카드용)">
+          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+            <input value={form.thumbnail_url ?? ""} onChange={set("thumbnail_url")} style={{ ...inp, flex: 1 }} placeholder="파일 업로드 또는 URL" />
+            <UploadBtn
+              busy={thumbUploading}
+              onFile={async (f) => {
+                setThumbUploading(true);
+                try {
+                  const { url } = await uploadPartnerImage(f);
+                  setForm((s) => ({ ...s, thumbnail_url: url }));
+                } catch (e: any) {
+                  alert(e?.message ?? "업로드 실패");
+                } finally {
+                  setThumbUploading(false);
+                }
+              }}
+            />
+          </div>
+          {form.thumbnail_url ? <img src={form.thumbnail_url} alt="" style={thumb} /> : null}
+        </Field>
+
+        <Field label="키워드 태그 (리스트 카드에 노출)">
+          <KeywordsEditor
+            value={form.keywords ?? []}
+            onChange={(keywords) => setForm((s) => ({ ...s, keywords }))}
+          />
+        </Field>
+
+        <Field label="치료항목 (카테고리별 가격·안내)">
+          <TreatmentItemsEditor
+            value={form.treatment_items ?? []}
+            onChange={(treatment_items) => setForm((s) => ({ ...s, treatment_items }))}
+          />
+        </Field>
+
+        <Field label="예약 링크 (선택)">
+          <input value={form.booking_url ?? ""} onChange={set("booking_url")} style={inp} placeholder="https://" />
         </Field>
 
         <div style={{ display: "flex", gap: 12 }}>


### PR DESCRIPTION
## 요약
병원 프로필 관리(관리자) + 파트너 포털에 모두닥 스타일 카드용 입력 필드와 리뷰 관리 화면 추가.

### 관리자 (병원 프로필 관리)
- **내부 병원 연결** (리뷰 자격 판정 키), 썸네일, 키워드 태그, 치료항목(카테고리+정상가/이벤트가+안내), 인증배지, 예약링크
- **리뷰 관리** 화면 신규 (`/admin/hospital-profiles/:placeId/reviews`) — 숨김/노출
- 실서비스 미리보기 버튼 포함 (#24 포함 — 이 PR로 대체 가능)

### 파트너 포털
- 썸네일/키워드/치료항목/예약링크 입력 (`hospital_id`·`verified`는 관리자 전용)

### 공용
- 치료 카테고리 상수(myodoc와 동기화) + 키워드/치료항목 에디터 컴포넌트

## 실서비스 영향
- 전부 additive — 기존 화면/라우트 변경 없음, 신규 필드/화면만 추가
- 의존: 백엔드 PR #30 먼저 배포

> #24(미리보기)를 포함하므로, 이 PR 머지 시 #24는 닫아도 됩니다.