### PR TITLE
feat(admin): 신고 목록에 원문 미리보기와 바로가기

### DIFF
--- a/src/api/moderation.ts
+++ b/src/api/moderation.ts
@@ -12,6 +12,12 @@ export interface ContentReport {
   detail: string | null;
   status: ReportStatus;
   createdAt: string;
+  /** Snippet of the reported content, so the queue is judgeable in place. */
+  preview: string | null;
+  /** Opens the content on the public web build; null if it no longer exists. */
+  contentUrl: string | null;
+  /** Already hidden or deleted — usually nothing left to do. */
+  contentGone: boolean;
 }
 
 export const TARGET_LABEL: Record<ReportTargetType, string> = {

--- a/src/routes/admin_reports.tsx
+++ b/src/routes/admin_reports.tsx
@@ -82,8 +82,8 @@ export default function AdminReports() {
           <thead>
             <tr>
               <th style={th}>대상</th>
+              <th style={th}>내용</th>
               <th style={th}>사유</th>
-              <th style={th}>상세</th>
               <th style={th}>접수일</th>
               <th style={th}>상태</th>
               <th style={th} />
@@ -94,11 +94,34 @@ export default function AdminReports() {
               <tr key={r.id}>
                 <td style={td}>
                   {TARGET_LABEL[r.targetType] ?? r.targetType}
-                  <br />
-                  <span style={{ color: "#9ca3af", fontSize: 11 }}>{r.targetId}</span>
+                  {r.contentGone && (
+                    <>
+                      <br />
+                      <span style={{ color: "#9ca3af", fontSize: 11 }}>이미 삭제/숨김</span>
+                    </>
+                  )}
+                </td>
+                <td style={{ ...td, maxWidth: 380 }}>
+                  <div style={{ color: r.contentGone ? "#9ca3af" : "#111", lineHeight: 1.45 }}>
+                    {r.preview ?? <span style={{ color: "#9ca3af" }}>내용 없음</span>}
+                  </div>
+                  {r.contentUrl && (
+                    <a
+                      href={r.contentUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      style={{ fontSize: 12, color: "#0d47a1" }}
+                    >
+                      원문 보기 ↗
+                    </a>
+                  )}
+                  {r.detail && (
+                    <div style={{ color: "#6b7280", fontSize: 12, marginTop: 4 }}>
+                      신고자 메모: {r.detail}
+                    </div>
+                  )}
                 </td>
                 <td style={td}>{REASON_LABEL[r.reason] ?? r.reason}</td>
-                <td style={{ ...td, maxWidth: 260 }}>{r.detail ?? "-"}</td>
                 <td style={td}>{r.createdAt.slice(0, 10)}</td>
                 <td style={td}>
                   <span style={badge(r.status)}>{STATUS_LABEL[r.status]}</span>


### PR DESCRIPTION
## 무엇

신고 처리 화면이 `target_id` uuid만 보여줘서, 관리자가 **무엇을 숨기는지 모르는 채로** 판단해야 했다.

- 내용 일부(140자) 미리보기
- "원문 보기 ↗" — 공개 웹에서 해당 글·투표·병원 페이지로 이동
- 이미 삭제·숨김된 건은 그렇게 표시 (할 일이 없다는 뜻)
- 신고자 메모는 내용 아래로 이동

## 실서비스 영향

`/admin/reports` 한 화면만 변경. lazy 라우트라 다른 페이지 번들에 영향 없음.

## 의존

myopiaBackend #34 (`preview` / `contentUrl` / `contentGone` 필드). 배포 전에는 미리보기가 비어 보인다.

## 검증

`tsc --noEmit` 통과