### PR TITLE
feat(admin): 치료항목 카테고리를 소아 근시 5종으로

### DIFF
--- a/src/components/hospitalCardEditors.tsx
+++ b/src/components/hospitalCardEditors.tsx
@@ -102,7 +102,7 @@ export function TreatmentItemsEditor({
             <input
               value={it.name}
               onChange={(e) => update(i, { name: e.target.value })}
-              placeholder="항목명 (예: 노안수술 검진)"
+              placeholder="항목명 (예: 드림렌즈 피팅)"
               style={{ ...inp, flex: 1 }}
             />
             <button

--- a/src/constants/treatmentCategories.ts
+++ b/src/constants/treatmentCategories.ts
@@ -2,15 +2,17 @@
 // (src/features/treatmentFinder/TreatmentCategoryScreen.tsx). A profile's
 // treatment_items are tagged with one of these keys so the app can surface the
 // right item when a user browses by category.
+// Childhood myopia only — the app's whole subject. This list used to carry
+// general adult ophthalmology (라식·백내장·노안수술) borrowed from a competitor
+// while prototyping, which put the hospital finder at odds with every other
+// part of the product. `dreamLens` keeps its old key so profiles already
+// tagged with it stay valid.
 export const TREATMENT_CATEGORIES = [
-  { key: "visionCorrection", label: "시력교정술" },
-  { key: "presbyopia", label: "노안수술" },
-  { key: "cataract", label: "백내장수술" },
   { key: "dreamLens", label: "드림렌즈" },
-  { key: "dryEyeIpl", label: "안구건조증 IPL" },
-  { key: "eyelid", label: "아이링수술" },
-  { key: "retina", label: "망막질환" },
-  { key: "etc", label: "기타" },
+  { key: "misight", label: "마이사이트" },
+  { key: "myopiaGlasses", label: "근시조절안경" },
+  { key: "atropine", label: "저농도 아트로핀" },
+  { key: "checkup", label: "근시 검진·상담" },
 ] as const;
 
 export type TreatmentCategoryKey = (typeof TREATMENT_CATEGORIES)[number]["key"];


### PR DESCRIPTION
병원이 뱃지를 등록할 때 고르는 목록이다. **앱과 같은 키를 써야 매칭되므로** myodoc의 치료항목 교체와 반드시 함께 나가야 한다.

```
드림렌즈 · 마이사이트 · 근시조절안경 · 저농도 아트로핀 · 근시 검진·상담
```

이전 목록(시력교정술·노안수술·백내장수술·안구건조증 IPL·아이링수술·망막질환)은 프로토타이핑 중 경쟁사에서 가져온 것으로, 소아 근시 관리라는 앱의 목적과 맞지 않았다.

관리자 화면과 파트너 화면이 **같은 컴포넌트**(`hospitalCardEditors`)를 쓰므로 양쪽에 자동 반영된다. 항목명 예시도 `노안수술 검진` → `드림렌즈 피팅`으로 바꿨다.

`dreamLens`는 키를 유지했다. 실서비스 프로필에 옛 키를 쓰는 데이터가 없는 것도 확인했다.

## 검증

`tsc --noEmit` 통과. 실서비스 영향은 병원 프로필 편집 화면의 선택지 목록뿐이다.

## 의존

myodoc #18 (같은 카테고리 키를 읽는 쪽)