### PR TITLE
feat(admin): 진료시간·소식 등록 UI

### DIFF
--- a/src/api/hospitalProfile.ts
+++ b/src/api/hospitalProfile.ts
@@ -22,6 +22,7 @@ export interface HospitalProfile {
   booking_url: string | null;
   created_at: string;
   updated_at: string;
+  opening_hours?: unknown | null;
 }
 
 export interface HospitalProfileInput {
@@ -39,6 +40,7 @@ export interface HospitalProfileInput {
   treatment_items?: TreatmentItem[];
   verified?: boolean;
   booking_url?: string | null;
+  opening_hours?: unknown | null;
 }
 
 export interface HospitalReview {
@@ -122,4 +124,56 @@ export async function uploadHospitalImage(file: File): Promise<{ url: string }> 
     throw new HttpError(result.status, respBody?.message);
   }
   return result.json();
+}
+
+/* ---- 소식 (clinic notices) --------------------------------------------- */
+
+export interface HospitalNotice {
+  id: string;
+  title: string;
+  body: string;
+  kind: "notice" | "event";
+  pinned: boolean;
+  published: boolean;
+  createdAt: string;
+}
+
+export interface HospitalNoticeInput {
+  title: string;
+  body: string;
+  kind?: "notice" | "event";
+  pinned?: boolean;
+  published?: boolean;
+}
+
+export function listHospitalNotices(profileId: string): Promise<HospitalNotice[]> {
+  return jsonFetchWithSession(`${API_ROOT}/hospital-profile/${profileId}/notices`);
+}
+
+export function createHospitalNotice(
+  profileId: string,
+  data: HospitalNoticeInput,
+): Promise<{ id: string }> {
+  return jsonFetchWithSession(
+    `${API_ROOT}/hospital-profile/${profileId}/notices`,
+    { method: "POST" },
+    data,
+  );
+}
+
+export function updateHospitalNotice(
+  noticeId: string,
+  data: Partial<HospitalNoticeInput>,
+): Promise<{ ok: boolean }> {
+  return jsonFetchWithSession(
+    `${API_ROOT}/hospital-profile/notices/${noticeId}`,
+    { method: "PATCH" },
+    data,
+  );
+}
+
+export function deleteHospitalNotice(noticeId: string): Promise<void> {
+  return jsonFetchWithSession(`${API_ROOT}/hospital-profile/notices/${noticeId}`, {
+    method: "DELETE",
+  });
 }

--- a/src/api/partner.ts
+++ b/src/api/partner.ts
@@ -74,6 +74,7 @@ export interface PartnerProfile {
   treatment_items: TreatmentItem[] | null;
   booking_url: string | null;
   status: string;
+  opening_hours?: unknown | null;
 }
 
 export interface PartnerProfileInput {

--- a/src/api/partner.ts
+++ b/src/api/partner.ts
@@ -88,6 +88,7 @@ export interface PartnerProfileInput {
   keywords?: string[];
   treatment_items?: TreatmentItem[];
   booking_url?: string | null;
+  opening_hours?: unknown | null;
 }
 
 export function partnerSignup(data: {

--- a/src/components/HospitalNoticesEditor.tsx
+++ b/src/components/HospitalNoticesEditor.tsx
@@ -8,7 +8,14 @@ import {
   type HospitalNotice,
 } from "../api/hospitalProfile";
 
-const EMPTY = { title: "", body: "", kind: "notice" as const, pinned: false };
+interface NoticeDraft {
+  title: string;
+  body: string;
+  kind: "notice" | "event";
+  pinned: boolean;
+}
+
+const EMPTY: NoticeDraft = { title: "", body: "", kind: "notice", pinned: false };
 
 /**
  * Clinic notices, managed from the admin profile page.
@@ -20,7 +27,7 @@ const EMPTY = { title: "", body: "", kind: "notice" as const, pinned: false };
  */
 export function HospitalNoticesEditor({ profileId }: { profileId: string | null }) {
   const [rows, setRows] = useState<HospitalNotice[]>([]);
-  const [draft, setDraft] = useState<typeof EMPTY>(EMPTY);
+  const [draft, setDraft] = useState<NoticeDraft>(EMPTY);
   const [busy, setBusy] = useState(false);
 
   const reload = () => {

--- a/src/components/HospitalNoticesEditor.tsx
+++ b/src/components/HospitalNoticesEditor.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useState, type CSSProperties } from "react";
+
+import {
+  createHospitalNotice,
+  deleteHospitalNotice,
+  listHospitalNotices,
+  updateHospitalNotice,
+  type HospitalNotice,
+} from "../api/hospitalProfile";
+
+const EMPTY = { title: "", body: "", kind: "notice" as const, pinned: false };
+
+/**
+ * Clinic notices, managed from the admin profile page.
+ *
+ * Lives outside the profile form because notices are their own records with
+ * their own lifetime — saving the profile shouldn't rewrite them, and adding
+ * one shouldn't require re-saving everything else. Only available once the
+ * profile exists, since a notice has to hang off one.
+ */
+export function HospitalNoticesEditor({ profileId }: { profileId: string | null }) {
+  const [rows, setRows] = useState<HospitalNotice[]>([]);
+  const [draft, setDraft] = useState<typeof EMPTY>(EMPTY);
+  const [busy, setBusy] = useState(false);
+
+  const reload = () => {
+    if (!profileId) return;
+    listHospitalNotices(profileId)
+      .then(setRows)
+      .catch(() => setRows([]));
+  };
+
+  useEffect(reload, [profileId]);
+
+  if (!profileId) {
+    return (
+      <p style={{ color: "#6b7280", fontSize: 13, margin: 0 }}>
+        프로필을 먼저 저장하면 소식을 등록할 수 있습니다.
+      </p>
+    );
+  }
+
+  const add = async () => {
+    if (!draft.title.trim() || !draft.body.trim()) {
+      alert("제목과 내용을 입력하세요.");
+      return;
+    }
+    setBusy(true);
+    try {
+      await createHospitalNotice(profileId, draft);
+      setDraft(EMPTY);
+      reload();
+    } catch (e: any) {
+      alert(e?.message ?? "등록 실패");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div>
+      <p style={{ color: "#6b7280", fontSize: 12, margin: "0 0 10px" }}>
+        재개원 안내, 원장 변경, 이벤트처럼 앱 병원 상세에 노출할 소식입니다. 고정한 소식이 항상 위에
+        표시됩니다.
+      </p>
+
+      <div style={{ display: "grid", gap: 6, marginBottom: 14 }}>
+        <div style={{ display: "flex", gap: 8 }}>
+          <select
+            value={draft.kind}
+            onChange={(e) => setDraft((d) => ({ ...d, kind: e.target.value as "notice" | "event" }))}
+            style={{ ...inp, flex: "0 0 110px" }}
+          >
+            <option value="notice">공지</option>
+            <option value="event">이벤트</option>
+          </select>
+          <input
+            value={draft.title}
+            onChange={(e) => setDraft((d) => ({ ...d, title: e.target.value }))}
+            placeholder="제목 (예: 8월 휴진 안내)"
+            style={{ ...inp, flex: 1 }}
+          />
+          <label style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 13 }}>
+            <input
+              type="checkbox"
+              checked={draft.pinned}
+              onChange={(e) => setDraft((d) => ({ ...d, pinned: e.target.checked }))}
+            />
+            고정
+          </label>
+        </div>
+        <textarea
+          value={draft.body}
+          onChange={(e) => setDraft((d) => ({ ...d, body: e.target.value }))}
+          placeholder="내용"
+          rows={4}
+          style={{ ...inp, width: "100%", resize: "vertical" }}
+        />
+        <div>
+          <button type="button" onClick={add} disabled={busy} style={addBtn}>
+            소식 추가
+          </button>
+        </div>
+      </div>
+
+      {rows.length === 0 ? (
+        <p style={{ color: "#9ca3af", fontSize: 13 }}>등록된 소식이 없습니다.</p>
+      ) : (
+        <div style={{ display: "grid", gap: 8 }}>
+          {rows.map((n) => (
+            <div key={n.id} style={card}>
+              <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                <span style={badge(n.kind)}>{n.kind === "event" ? "이벤트" : "공지"}</span>
+                <strong style={{ flex: 1 }}>{n.title}</strong>
+                <label style={{ fontSize: 12, display: "flex", gap: 4, alignItems: "center" }}>
+                  <input
+                    type="checkbox"
+                    checked={n.pinned}
+                    onChange={async (e) => {
+                      await updateHospitalNotice(n.id, { pinned: e.target.checked });
+                      reload();
+                    }}
+                  />
+                  고정
+                </label>
+                <label style={{ fontSize: 12, display: "flex", gap: 4, alignItems: "center" }}>
+                  <input
+                    type="checkbox"
+                    checked={n.published}
+                    onChange={async (e) => {
+                      await updateHospitalNotice(n.id, { published: e.target.checked });
+                      reload();
+                    }}
+                  />
+                  노출
+                </label>
+                <button
+                  type="button"
+                  onClick={async () => {
+                    if (!confirm("이 소식을 삭제할까요?")) return;
+                    await deleteHospitalNotice(n.id);
+                    reload();
+                  }}
+                  style={delBtn}
+                >
+                  삭제
+                </button>
+              </div>
+              <p style={{ margin: "8px 0 0", whiteSpace: "pre-wrap", color: "#374151", fontSize: 13 }}>
+                {n.body}
+              </p>
+              <span style={{ color: "#9ca3af", fontSize: 11 }}>{n.createdAt.slice(0, 10)}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const inp: CSSProperties = {
+  padding: "8px 10px",
+  border: "1px solid #ddd",
+  borderRadius: 8,
+  fontSize: 14,
+};
+const card: CSSProperties = {
+  border: "1px solid #e5e7eb",
+  borderRadius: 10,
+  padding: 12,
+  background: "#fff",
+};
+const addBtn: CSSProperties = {
+  padding: "8px 16px",
+  borderRadius: 8,
+  border: "1px solid #0d47a1",
+  background: "#0d47a1",
+  color: "#fff",
+  cursor: "pointer",
+  fontSize: 13,
+};
+const delBtn: CSSProperties = {
+  padding: "4px 10px",
+  borderRadius: 6,
+  border: "1px solid #e0245e",
+  background: "#fff",
+  color: "#e0245e",
+  cursor: "pointer",
+  fontSize: 12,
+};
+function badge(kind: string): CSSProperties {
+  return {
+    background: kind === "event" ? "#FDE9C8" : "#FFF6B8",
+    color: "#36475A",
+    borderRadius: 6,
+    padding: "1px 8px",
+    fontSize: 12,
+    fontWeight: 700,
+  };
+}

--- a/src/components/hospitalCardEditors.tsx
+++ b/src/components/hospitalCardEditors.tsx
@@ -187,3 +187,119 @@ const itemCard: CSSProperties = {
   marginBottom: 10,
   background: "#fafafa",
 };
+
+/* ---- 진료시간 ------------------------------------------------------------ */
+
+const DAYS = [
+  { key: "mon", label: "월" },
+  { key: "tue", label: "화" },
+  { key: "wed", label: "수" },
+  { key: "thu", label: "목" },
+  { key: "fri", label: "금" },
+  { key: "sat", label: "토" },
+  { key: "sun", label: "일" },
+] as const;
+
+export interface DayHours {
+  open: string;
+  close: string;
+  lunchStart?: string | null;
+  lunchEnd?: string | null;
+}
+export type OpeningHours = Partial<Record<(typeof DAYS)[number]["key"], DayHours | null>> & {
+  note?: string;
+};
+
+/**
+ * Weekly hours grid. No map API supplies these, so the clinic enters them.
+ *
+ * Unchecking a day sets it to null (휴진) rather than deleting the key — the
+ * app needs to tell "closed on Sunday" apart from "hasn't filled this in yet",
+ * and only the second one should hide the section.
+ */
+export function OpeningHoursEditor({
+  value,
+  onChange,
+}: {
+  value: OpeningHours | null;
+  onChange: (v: OpeningHours | null) => void;
+}) {
+  const hours = value ?? {};
+  const setDay = (key: string, d: DayHours | null) => onChange({ ...hours, [key]: d });
+
+  return (
+    <div>
+      <div style={{ display: "flex", gap: 8, alignItems: "center", marginBottom: 8 }}>
+        <strong style={{ fontSize: 14 }}>진료시간</strong>
+        {value != null && (
+          <button type="button" onClick={() => onChange(null)} style={smallBtnDanger}>
+            전체 삭제
+          </button>
+        )}
+      </div>
+      <p style={{ color: "#6b7280", fontSize: 12, margin: "0 0 10px" }}>
+        체크를 해제하면 그 요일은 휴진으로 표시됩니다. 아무것도 입력하지 않으면 앱에서 진료시간
+        섹션 자체가 표시되지 않습니다.
+      </p>
+      <div style={{ display: "grid", gap: 6 }}>
+        {DAYS.map(({ key, label }) => {
+          const d = hours[key];
+          const open = d != null;
+          return (
+            <div key={key} style={{ display: "flex", gap: 8, alignItems: "center" }}>
+              <label style={{ width: 64, display: "flex", gap: 6, alignItems: "center" }}>
+                <input
+                  type="checkbox"
+                  checked={open}
+                  onChange={(e) =>
+                    setDay(key, e.target.checked ? { open: "09:00", close: "18:00" } : null)
+                  }
+                />
+                {label}
+              </label>
+              {open ? (
+                <>
+                  <input
+                    type="time"
+                    value={d.open}
+                    onChange={(e) => setDay(key, { ...d, open: e.target.value })}
+                    style={{ ...inp, width: 110 }}
+                  />
+                  <span>~</span>
+                  <input
+                    type="time"
+                    value={d.close}
+                    onChange={(e) => setDay(key, { ...d, close: e.target.value })}
+                    style={{ ...inp, width: 110 }}
+                  />
+                  <span style={{ color: "#6b7280", fontSize: 12 }}>점심</span>
+                  <input
+                    type="time"
+                    value={d.lunchStart ?? ""}
+                    onChange={(e) => setDay(key, { ...d, lunchStart: e.target.value || null })}
+                    style={{ ...inp, width: 110 }}
+                  />
+                  <span>~</span>
+                  <input
+                    type="time"
+                    value={d.lunchEnd ?? ""}
+                    onChange={(e) => setDay(key, { ...d, lunchEnd: e.target.value || null })}
+                    style={{ ...inp, width: 110 }}
+                  />
+                </>
+              ) : (
+                <span style={{ color: "#9ca3af", fontSize: 13 }}>휴진</span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+      <input
+        value={hours.note ?? ""}
+        onChange={(e) => onChange({ ...hours, note: e.target.value })}
+        placeholder="추가 안내 (예: 공휴일 휴진, 예약제 운영)"
+        style={{ ...inp, width: "100%", marginTop: 10 }}
+      />
+    </div>
+  );
+}

--- a/src/routes/admin_hospital_profiles.tsx
+++ b/src/routes/admin_hospital_profiles.tsx
@@ -13,7 +13,12 @@ import {
   type HospitalProfileInput,
 } from "../api/hospitalProfile";
 import { getHospitalList } from "../api/hospital";
-import { KeywordsEditor, TreatmentItemsEditor } from "../components/hospitalCardEditors";
+import {
+  KeywordsEditor,
+  OpeningHoursEditor,
+  TreatmentItemsEditor,
+} from "../components/hospitalCardEditors";
+import { HospitalNoticesEditor } from "../components/HospitalNoticesEditor";
 
 interface HospitalListItem {
   id: string;
@@ -51,6 +56,7 @@ const EMPTY: HospitalProfileInput = {
   thumbnail_url: "",
   keywords: [],
   treatment_items: [],
+  opening_hours: null,
   verified: false,
   booking_url: "",
 };
@@ -126,6 +132,7 @@ export default function AdminHospitalProfiles() {
       thumbnail_url: h.thumbnail_url ?? "",
       keywords: h.keywords ?? [],
       treatment_items: h.treatment_items ?? [],
+      opening_hours: h.opening_hours ?? null,
       verified: h.verified ?? false,
       booking_url: h.booking_url ?? "",
     });
@@ -221,6 +228,17 @@ export default function AdminHospitalProfiles() {
           <KeywordsEditor
             value={form.keywords ?? []}
             onChange={(keywords) => setForm((f) => ({ ...f, keywords }))}
+          />
+        </Field>
+
+        <Field label="병원 소식 (공지·이벤트)">
+          <HospitalNoticesEditor profileId={editingId} />
+        </Field>
+
+        <Field label="진료시간">
+          <OpeningHoursEditor
+            value={form.opening_hours ?? null}
+            onChange={(opening_hours) => setForm((f) => ({ ...f, opening_hours }))}
           />
         </Field>
 

--- a/src/routes/partner/PartnerProfile.tsx
+++ b/src/routes/partner/PartnerProfile.tsx
@@ -11,7 +11,11 @@ import {
   type PartnerMe,
   type PartnerProfileInput,
 } from "../../api/partner";
-import { KeywordsEditor, TreatmentItemsEditor } from "../../components/hospitalCardEditors";
+import {
+  KeywordsEditor,
+  OpeningHoursEditor,
+  TreatmentItemsEditor,
+} from "../../components/hospitalCardEditors";
 
 const EMPTY: PartnerProfileInput = {
   kakao_place_id: "",
@@ -24,6 +28,7 @@ const EMPTY: PartnerProfileInput = {
   thumbnail_url: "",
   keywords: [],
   treatment_items: [],
+  opening_hours: null,
   booking_url: "",
 };
 
@@ -58,6 +63,7 @@ export default function PartnerProfile() {
             thumbnail_url: p.thumbnail_url ?? "",
             keywords: p.keywords ?? [],
             treatment_items: p.treatment_items ?? [],
+            opening_hours: p.opening_hours ?? null,
             booking_url: p.booking_url ?? "",
           });
         } else {
@@ -204,6 +210,13 @@ export default function PartnerProfile() {
           <KeywordsEditor
             value={form.keywords ?? []}
             onChange={(keywords) => setForm((s) => ({ ...s, keywords }))}
+          />
+        </Field>
+
+        <Field label="진료시간">
+          <OpeningHoursEditor
+            value={form.opening_hours ?? null}
+            onChange={(opening_hours) => setForm((s) => ({ ...s, opening_hours }))}
           />
         </Field>
 


### PR DESCRIPTION
myopiaBackend #42가 받는 두 가지를 입력하는 화면.

## 진료시간

요일별 진료·점심시간 그리드. 관리자·파트너 양쪽 폼에 붙였다.

**체크를 해제하면 그 요일은 키를 지우는 대신 `null`로 남긴다.** 앱이 "일요일 휴진"과 "아직 입력 안 함"을 구분해야 하고, **후자만 섹션을 감춰야** 하기 때문이다.

## 소식 (공지·이벤트)

프로필 폼 **바깥**의 독립 컴포넌트다. 소식은 자체 수명을 가진 별개 레코드라서, 프로필을 저장할 때 함께 덮어써지면 안 되고 소식 하나 추가하려고 나머지를 다시 저장할 이유도 없다.

프로필이 저장되기 전에는 안내 문구만 보여준다 — 소식은 프로필에 매달리는 레코드라 붙을 곳이 있어야 한다.

관리자 화면에 먼저 뒀다. 온보딩 초기에는 병원이 직접 쓰지 않을 것이므로 대신 넣어줄 수 있어야 한다.

## 검증

`tsc --noEmit` 통과.

## 의존

myopiaBackend #42