### PR TITLE
feat(admin): 프로필 편집 탭 분리 + 이미지 등록 개편

### DIFF
--- a/src/api/hospitalProfile.ts
+++ b/src/api/hospitalProfile.ts
@@ -4,6 +4,11 @@ import type { TreatmentItem } from "../constants/treatmentCategories";
 
 export type HospitalProfileStatus = "draft" | "pending" | "published";
 
+/** Blog-style body block: a paragraph or a picture, in order. */
+export type DetailBlock =
+  | { type: "text"; text: string }
+  | { type: "image"; url: string };
+
 export interface HospitalProfile {
   id: string;
   kakao_place_id: string;
@@ -23,6 +28,8 @@ export interface HospitalProfile {
   created_at: string;
   updated_at: string;
   opening_hours?: unknown | null;
+  tagline?: string | null;
+  detail_blocks?: DetailBlock[] | null;
 }
 
 export interface HospitalProfileInput {
@@ -41,6 +48,8 @@ export interface HospitalProfileInput {
   verified?: boolean;
   booking_url?: string | null;
   opening_hours?: unknown | null;
+  tagline?: string | null;
+  detail_blocks?: DetailBlock[] | null;
 }
 
 export interface HospitalReview {
@@ -112,6 +121,30 @@ export async function uploadHospitalImage(file: File): Promise<{ url: string }> 
   body.append("image", file);
 
   const result = await fetch(API_ROOT + "/hospital-profile/upload", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${session_key}` },
+    body,
+  });
+  if (result.status === 401 || result.status === 403) {
+    throw new AuthorizationError("Authorization error");
+  }
+  if (!result.ok) {
+    const respBody = await result.json().catch(() => ({}));
+    throw new HttpError(result.status, respBody?.message);
+  }
+  return result.json();
+}
+
+/** Several images in one request — picking banner photos one at a time is the
+ *  slowest part of setting a profile up. */
+export async function uploadHospitalImages(files: File[]): Promise<{ urls: string[] }> {
+  const session_key = localStorage.getItem("session_key");
+  if (!session_key) throw new AuthorizationError("Authorization error");
+
+  const body = new FormData();
+  for (const f of files) body.append("images", f);
+
+  const result = await fetch(API_ROOT + "/hospital-profile/upload-many", {
     method: "POST",
     headers: { Authorization: `Bearer ${session_key}` },
     body,

--- a/src/api/hospitalProfile.ts
+++ b/src/api/hospitalProfile.ts
@@ -210,3 +210,18 @@ export function deleteHospitalNotice(noticeId: string): Promise<void> {
     method: "DELETE",
   });
 }
+
+/**
+ * Blank URL inputs mean "not set", but the API validates them as URLs and
+ * rejects `""` outright. Forms keep empty strings because that's what an empty
+ * text input holds, so normalise on the way out rather than scattering
+ * `|| null` across every field.
+ */
+export function normaliseProfileUrls<T extends object>(form: T): T {
+  const URL_FIELDS = ["banner_image_url", "thumbnail_url", "booking_url"];
+  const out = { ...form } as Record<string, unknown>;
+  for (const k of URL_FIELDS) {
+    if (typeof out[k] === "string" && (out[k] as string).trim() === "") out[k] = null;
+  }
+  return out as T;
+}

--- a/src/api/partner.ts
+++ b/src/api/partner.ts
@@ -75,6 +75,8 @@ export interface PartnerProfile {
   booking_url: string | null;
   status: string;
   opening_hours?: unknown | null;
+  tagline?: string | null;
+  detail_blocks?: import("./hospitalProfile").DetailBlock[] | null;
 }
 
 export interface PartnerProfileInput {
@@ -90,6 +92,8 @@ export interface PartnerProfileInput {
   treatment_items?: TreatmentItem[];
   booking_url?: string | null;
   opening_hours?: unknown | null;
+  tagline?: string | null;
+  detail_blocks?: import("./hospitalProfile").DetailBlock[] | null;
 }
 
 export function partnerSignup(data: {
@@ -124,6 +128,23 @@ export function savePartnerProfile(data: PartnerProfileInput): Promise<PartnerPr
   return partnerFetch("/partner/profile", { method: "PUT" }, data);
 }
 
+export async function uploadPartnerImages(files: File[]): Promise<{ urls: string[] }> {
+  const token = getPartnerToken();
+  if (!token) throw new PartnerError(401, "not logged in");
+  const fd = new FormData();
+  for (const f of files) fd.append("images", f);
+  const res = await fetch(API_ROOT + "/partner/profile/upload-many", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}` },
+    body: fd,
+  });
+  if (!res.ok) {
+    const b = await res.json().catch(() => ({}));
+    throw new PartnerError(res.status, b?.message);
+  }
+  return res.json();
+}
+
 export async function uploadPartnerImage(file: File): Promise<{ url: string }> {
   const token = getPartnerToken();
   if (!token) throw new PartnerError(401, "not logged in");
@@ -139,4 +160,43 @@ export async function uploadPartnerImage(file: File): Promise<{ url: string }> {
     throw new PartnerError(res.status, b?.message);
   }
   return res.json();
+}
+
+/* ---- 소식 (clinic notices) --------------------------------------------- */
+
+export interface PartnerNotice {
+  id: string;
+  title: string;
+  body: string;
+  kind: "notice" | "event";
+  pinned: boolean;
+  published: boolean;
+  createdAt: string;
+}
+
+export interface PartnerNoticeInput {
+  title: string;
+  body: string;
+  kind?: "notice" | "event";
+  pinned?: boolean;
+  published?: boolean;
+}
+
+export function listPartnerNotices(): Promise<{ notices: PartnerNotice[] }> {
+  return partnerFetch("/partner/notices");
+}
+
+export function createPartnerNotice(data: PartnerNoticeInput): Promise<{ id: string }> {
+  return partnerFetch("/partner/notices", { method: "POST" }, data);
+}
+
+export function updatePartnerNotice(
+  id: string,
+  data: Partial<PartnerNoticeInput>,
+): Promise<{ ok: boolean }> {
+  return partnerFetch(`/partner/notices/${id}`, { method: "PATCH" }, data);
+}
+
+export function deletePartnerNotice(id: string): Promise<void> {
+  return partnerFetch(`/partner/notices/${id}`, { method: "DELETE" });
 }

--- a/src/components/FormTabs.tsx
+++ b/src/components/FormTabs.tsx
@@ -1,0 +1,65 @@
+import { useState, type CSSProperties, type ReactNode } from "react";
+
+export interface FormTab {
+  key: string;
+  label: string;
+  content: ReactNode;
+}
+
+/**
+ * Tab strip for the hospital profile form.
+ *
+ * The form had grown to a dozen unrelated groups in one column — basics, photos,
+ * hours, prices, notices — so setting up a clinic meant scrolling past
+ * everything you weren't doing. Every tab stays mounted so a single Save still
+ * submits the whole form; hidden panels are only visually hidden.
+ */
+export function FormTabs({ tabs }: { tabs: FormTab[] }) {
+  const [active, setActive] = useState(tabs[0]?.key);
+
+  return (
+    <div>
+      <div style={strip}>
+        {tabs.map((t) => {
+          const on = t.key === active;
+          return (
+            <button
+              key={t.key}
+              type="button"
+              onClick={() => setActive(t.key)}
+              style={{
+                ...tabBtn,
+                color: on ? "#0d47a1" : "#6b7280",
+                fontWeight: on ? 700 : 500,
+                borderBottomColor: on ? "#0d47a1" : "transparent",
+              }}
+            >
+              {t.label}
+            </button>
+          );
+        })}
+      </div>
+      {tabs.map((t) => (
+        <div key={t.key} style={{ display: t.key === active ? "block" : "none", paddingTop: 18 }}>
+          {t.content}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const strip: CSSProperties = {
+  display: "flex",
+  gap: 4,
+  borderBottom: "1px solid #e5e7eb",
+  overflowX: "auto",
+};
+const tabBtn: CSSProperties = {
+  padding: "10px 16px",
+  background: "none",
+  border: "none",
+  borderBottom: "2px solid transparent",
+  cursor: "pointer",
+  fontSize: 14,
+  whiteSpace: "nowrap",
+};

--- a/src/components/HospitalContentEditors.tsx
+++ b/src/components/HospitalContentEditors.tsx
@@ -1,0 +1,285 @@
+import { useRef, useState, type CSSProperties } from "react";
+
+import type { DetailBlock } from "../api/hospitalProfile";
+
+export const MAX_BANNERS = 10;
+
+type UploadMany = (files: File[]) => Promise<{ urls: string[] }>;
+
+/**
+ * Banner carousel: pick several files at once, reorder, remove.
+ *
+ * Uploading one file at a time was the slowest part of setting up a profile —
+ * a clinic has a folder of photos, not one photo. Capped at ten because past
+ * that nobody swipes and the page just gets heavier.
+ */
+export function BannerImagesEditor({
+  value,
+  onChange,
+  upload,
+}: {
+  value: string[];
+  onChange: (v: string[]) => void;
+  upload: UploadMany;
+}) {
+  const [busy, setBusy] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const room = MAX_BANNERS - value.length;
+
+  const pick = async (files: FileList | null) => {
+    if (!files || files.length === 0) return;
+    const chosen = Array.from(files).slice(0, room);
+    if (chosen.length < files.length) {
+      alert(`배너는 최대 ${MAX_BANNERS}장까지 등록할 수 있어 ${chosen.length}장만 추가합니다.`);
+    }
+    setBusy(true);
+    try {
+      const { urls } = await upload(chosen);
+      onChange([...value, ...urls]);
+    } catch (e: any) {
+      alert(e?.message ?? "업로드 실패");
+    } finally {
+      setBusy(false);
+      if (inputRef.current) inputRef.current.value = "";
+    }
+  };
+
+  const move = (i: number, dir: -1 | 1) => {
+    const j = i + dir;
+    if (j < 0 || j >= value.length) return;
+    const next = [...value];
+    [next[i], next[j]] = [next[j], next[i]];
+    onChange(next);
+  };
+
+  return (
+    <div>
+      <p style={hint}>
+        앱 병원 상세 상단에 좌우로 넘기며 보이는 사진입니다. 첫 번째 사진이 대표로 쓰입니다. 최대{" "}
+        {MAX_BANNERS}장.
+      </p>
+
+      <div style={{ display: "flex", gap: 8, alignItems: "center", marginBottom: 10 }}>
+        <input
+          ref={inputRef}
+          type="file"
+          accept="image/*"
+          multiple
+          disabled={busy || room <= 0}
+          onChange={(e) => void pick(e.target.files)}
+        />
+        <span style={{ color: "#6b7280", fontSize: 12 }}>
+          {busy ? "업로드 중…" : `${value.length} / ${MAX_BANNERS}`}
+        </span>
+      </div>
+
+      {value.length === 0 ? (
+        <p style={{ color: "#9ca3af", fontSize: 13 }}>등록된 배너 사진이 없습니다.</p>
+      ) : (
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 10 }}>
+          {value.map((url, i) => (
+            <div key={url + i} style={thumbBox}>
+              <img src={url} alt="" style={thumbImg} />
+              <div style={{ display: "flex", gap: 4, marginTop: 4 }}>
+                <button type="button" onClick={() => move(i, -1)} style={tinyBtn} disabled={i === 0}>
+                  ←
+                </button>
+                <button
+                  type="button"
+                  onClick={() => move(i, 1)}
+                  style={tinyBtn}
+                  disabled={i === value.length - 1}
+                >
+                  →
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onChange(value.filter((_, idx) => idx !== i))}
+                  style={{ ...tinyBtn, color: "#e0245e", borderColor: "#e0245e" }}
+                >
+                  삭제
+                </button>
+              </div>
+              {i === 0 && <span style={mainTag}>대표</span>}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Blog-style body: paragraphs and pictures in the order the clinic wants.
+ *
+ * A single text field plus a flat gallery can't say "here's the procedure, and
+ * here's what it looks like" — the picture has to sit next to the paragraph it
+ * belongs to.
+ */
+export function DetailBlocksEditor({
+  value,
+  onChange,
+  upload,
+}: {
+  value: DetailBlock[];
+  onChange: (v: DetailBlock[]) => void;
+  upload: UploadMany;
+}) {
+  const [busy, setBusy] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const set = (i: number, b: DetailBlock) =>
+    onChange(value.map((x, idx) => (idx === i ? b : x)));
+  const remove = (i: number) => onChange(value.filter((_, idx) => idx !== i));
+  const move = (i: number, dir: -1 | 1) => {
+    const j = i + dir;
+    if (j < 0 || j >= value.length) return;
+    const next = [...value];
+    [next[i], next[j]] = [next[j], next[i]];
+    onChange(next);
+  };
+
+  const addImages = async (files: FileList | null) => {
+    if (!files || files.length === 0) return;
+    setBusy(true);
+    try {
+      const { urls } = await upload(Array.from(files));
+      onChange([...value, ...urls.map((url) => ({ type: "image" as const, url }))]);
+    } catch (e: any) {
+      alert(e?.message ?? "업로드 실패");
+    } finally {
+      setBusy(false);
+      if (inputRef.current) inputRef.current.value = "";
+    }
+  };
+
+  return (
+    <div>
+      <p style={hint}>
+        글과 사진을 원하는 순서로 배치합니다. 블로그 글쓰기처럼 문단 사이에 사진을 넣을 수 있습니다.
+      </p>
+
+      <div style={{ display: "grid", gap: 8, marginBottom: 12 }}>
+        {value.length === 0 && (
+          <p style={{ color: "#9ca3af", fontSize: 13, margin: 0 }}>
+            아직 내용이 없습니다. 아래에서 글이나 사진을 추가하세요.
+          </p>
+        )}
+        {value.map((b, i) => (
+          <div key={i} style={blockBox}>
+            <div style={{ display: "flex", gap: 4, marginBottom: 6 }}>
+              <span style={blockTag}>{b.type === "text" ? "글" : "사진"}</span>
+              <div style={{ flex: 1 }} />
+              <button type="button" onClick={() => move(i, -1)} style={tinyBtn} disabled={i === 0}>
+                ↑
+              </button>
+              <button
+                type="button"
+                onClick={() => move(i, 1)}
+                style={tinyBtn}
+                disabled={i === value.length - 1}
+              >
+                ↓
+              </button>
+              <button
+                type="button"
+                onClick={() => remove(i)}
+                style={{ ...tinyBtn, color: "#e0245e", borderColor: "#e0245e" }}
+              >
+                삭제
+              </button>
+            </div>
+            {b.type === "text" ? (
+              <textarea
+                value={b.text}
+                onChange={(e) => set(i, { type: "text", text: e.target.value })}
+                rows={4}
+                placeholder="내용을 입력하세요"
+                style={{ ...inp, width: "100%", resize: "vertical" }}
+              />
+            ) : (
+              <img src={b.url} alt="" style={{ maxWidth: "100%", borderRadius: 8 }} />
+            )}
+          </div>
+        ))}
+      </div>
+
+      <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+        <button
+          type="button"
+          onClick={() => onChange([...value, { type: "text", text: "" }])}
+          style={addBtn}
+        >
+          + 글 추가
+        </button>
+        <input
+          ref={inputRef}
+          type="file"
+          accept="image/*"
+          multiple
+          disabled={busy}
+          onChange={(e) => void addImages(e.target.files)}
+        />
+        {busy && <span style={{ color: "#6b7280", fontSize: 12 }}>업로드 중…</span>}
+      </div>
+    </div>
+  );
+}
+
+const hint: CSSProperties = { color: "#6b7280", fontSize: 12, margin: "0 0 10px" };
+const inp: CSSProperties = {
+  padding: "8px 10px",
+  border: "1px solid #ddd",
+  borderRadius: 8,
+  fontSize: 14,
+};
+const thumbBox: CSSProperties = { position: "relative", width: 140 };
+const thumbImg: CSSProperties = {
+  width: 140,
+  height: 92,
+  objectFit: "cover",
+  borderRadius: 8,
+  border: "1px solid #e5e7eb",
+  display: "block",
+};
+const mainTag: CSSProperties = {
+  position: "absolute",
+  top: 6,
+  left: 6,
+  background: "rgba(0,0,0,0.6)",
+  color: "#fff",
+  fontSize: 11,
+  borderRadius: 4,
+  padding: "1px 6px",
+};
+const tinyBtn: CSSProperties = {
+  padding: "2px 8px",
+  fontSize: 12,
+  borderRadius: 6,
+  border: "1px solid #ddd",
+  background: "#fff",
+  cursor: "pointer",
+};
+const blockBox: CSSProperties = {
+  border: "1px solid #e5e7eb",
+  borderRadius: 10,
+  padding: 12,
+  background: "#fff",
+};
+const blockTag: CSSProperties = {
+  background: "#eef2f7",
+  color: "#36475A",
+  borderRadius: 6,
+  padding: "1px 8px",
+  fontSize: 12,
+  fontWeight: 700,
+};
+const addBtn: CSSProperties = {
+  padding: "6px 14px",
+  borderRadius: 8,
+  border: "1px solid #0d47a1",
+  background: "#fff",
+  color: "#0d47a1",
+  cursor: "pointer",
+  fontSize: 13,
+};

--- a/src/components/PartnerNoticesEditor.tsx
+++ b/src/components/PartnerNoticesEditor.tsx
@@ -1,0 +1,207 @@
+import { useEffect, useState, type CSSProperties } from "react";
+
+import {
+  createPartnerNotice,
+  deletePartnerNotice,
+  listPartnerNotices,
+  updatePartnerNotice,
+  type PartnerNotice,
+} from "../api/partner";
+
+interface Draft {
+  title: string;
+  body: string;
+  kind: "notice" | "event";
+  pinned: boolean;
+}
+
+const EMPTY: Draft = { title: "", body: "", kind: "notice", pinned: false };
+
+/**
+ * Clinic notices, written by the clinic itself.
+ *
+ * The API resolves the profile from the logged-in partner, so this component
+ * never handles a profile id — a clinic can only ever touch its own notices.
+ */
+export function PartnerNoticesEditor() {
+  const [rows, setRows] = useState<PartnerNotice[]>([]);
+  const [draft, setDraft] = useState<Draft>(EMPTY);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const reload = () => {
+    listPartnerNotices()
+      .then((r) => setRows(r.notices))
+      .catch(() => setRows([]));
+  };
+
+  useEffect(reload, []);
+
+  const add = async () => {
+    if (!draft.title.trim() || !draft.body.trim()) {
+      setErr("제목과 내용을 입력하세요.");
+      return;
+    }
+    setBusy(true);
+    setErr(null);
+    try {
+      await createPartnerNotice(draft);
+      setDraft(EMPTY);
+      reload();
+    } catch (e: any) {
+      // 409 = the profile hasn't been saved yet, so there's nothing to hang a
+      // notice off. Say that rather than showing a bare error.
+      setErr(
+        e?.status === 409
+          ? "프로필을 먼저 저장한 뒤 소식을 등록할 수 있습니다."
+          : (e?.message ?? "등록 실패"),
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div>
+      <p style={hint}>
+        재개원 안내, 원장 변경, 이벤트처럼 앱 병원 상세에 노출할 소식입니다. 고정한 소식이 항상 위에
+        표시됩니다.
+      </p>
+
+      <div style={{ display: "grid", gap: 6, marginBottom: 14 }}>
+        <div style={{ display: "flex", gap: 8 }}>
+          <select
+            value={draft.kind}
+            onChange={(e) => setDraft((d) => ({ ...d, kind: e.target.value as Draft["kind"] }))}
+            style={{ ...inp, flex: "0 0 110px" }}
+          >
+            <option value="notice">공지</option>
+            <option value="event">이벤트</option>
+          </select>
+          <input
+            value={draft.title}
+            onChange={(e) => setDraft((d) => ({ ...d, title: e.target.value }))}
+            placeholder="제목 (예: 8월 휴진 안내)"
+            style={{ ...inp, flex: 1 }}
+          />
+          <label style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 13 }}>
+            <input
+              type="checkbox"
+              checked={draft.pinned}
+              onChange={(e) => setDraft((d) => ({ ...d, pinned: e.target.checked }))}
+            />
+            고정
+          </label>
+        </div>
+        <textarea
+          value={draft.body}
+          onChange={(e) => setDraft((d) => ({ ...d, body: e.target.value }))}
+          placeholder="내용"
+          rows={4}
+          style={{ ...inp, width: "100%", resize: "vertical" }}
+        />
+        {err && <p style={{ color: "#b3261e", fontSize: 13, margin: 0 }}>{err}</p>}
+        <div>
+          <button type="button" onClick={add} disabled={busy} style={addBtn}>
+            소식 추가
+          </button>
+        </div>
+      </div>
+
+      {rows.length === 0 ? (
+        <p style={{ color: "#9ca3af", fontSize: 13 }}>등록된 소식이 없습니다.</p>
+      ) : (
+        <div style={{ display: "grid", gap: 8 }}>
+          {rows.map((n) => (
+            <div key={n.id} style={card}>
+              <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                <span style={badge(n.kind)}>{n.kind === "event" ? "이벤트" : "공지"}</span>
+                <strong style={{ flex: 1 }}>{n.title}</strong>
+                <label style={check}>
+                  <input
+                    type="checkbox"
+                    checked={n.pinned}
+                    onChange={async (e) => {
+                      await updatePartnerNotice(n.id, { pinned: e.target.checked });
+                      reload();
+                    }}
+                  />
+                  고정
+                </label>
+                <label style={check}>
+                  <input
+                    type="checkbox"
+                    checked={n.published}
+                    onChange={async (e) => {
+                      await updatePartnerNotice(n.id, { published: e.target.checked });
+                      reload();
+                    }}
+                  />
+                  노출
+                </label>
+                <button
+                  type="button"
+                  onClick={async () => {
+                    if (!confirm("이 소식을 삭제할까요?")) return;
+                    await deletePartnerNotice(n.id);
+                    reload();
+                  }}
+                  style={delBtn}
+                >
+                  삭제
+                </button>
+              </div>
+              <p style={{ margin: "8px 0 0", whiteSpace: "pre-wrap", color: "#374151", fontSize: 13 }}>
+                {n.body}
+              </p>
+              <span style={{ color: "#9ca3af", fontSize: 11 }}>{n.createdAt.slice(0, 10)}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const hint: CSSProperties = { color: "#6b7280", fontSize: 12, margin: "0 0 10px" };
+const inp: CSSProperties = {
+  padding: "8px 10px",
+  border: "1px solid #ddd",
+  borderRadius: 8,
+  fontSize: 14,
+};
+const card: CSSProperties = {
+  border: "1px solid #e5e7eb",
+  borderRadius: 10,
+  padding: 12,
+  background: "#fff",
+};
+const check: CSSProperties = { fontSize: 12, display: "flex", gap: 4, alignItems: "center" };
+const addBtn: CSSProperties = {
+  padding: "8px 16px",
+  borderRadius: 8,
+  border: "1px solid #0d47a1",
+  background: "#0d47a1",
+  color: "#fff",
+  cursor: "pointer",
+  fontSize: 13,
+};
+const delBtn: CSSProperties = {
+  padding: "4px 10px",
+  borderRadius: 6,
+  border: "1px solid #e0245e",
+  background: "#fff",
+  color: "#e0245e",
+  cursor: "pointer",
+  fontSize: 12,
+};
+function badge(kind: string): CSSProperties {
+  return {
+    background: kind === "event" ? "#FDE9C8" : "#FFF6B8",
+    color: "#36475A",
+    borderRadius: 6,
+    padding: "1px 8px",
+    fontSize: 12,
+    fontWeight: 700,
+  };
+}

--- a/src/routes/admin_hospital_profiles.tsx
+++ b/src/routes/admin_hospital_profiles.tsx
@@ -9,6 +9,7 @@ import {
   listHospitalProfiles,
   updateHospitalProfile,
   uploadHospitalImage,
+  uploadHospitalImages,
   type HospitalProfile,
   type HospitalProfileInput,
 } from "../api/hospitalProfile";
@@ -18,6 +19,8 @@ import {
   OpeningHoursEditor,
   TreatmentItemsEditor,
 } from "../components/hospitalCardEditors";
+import { BannerImagesEditor, DetailBlocksEditor } from "../components/HospitalContentEditors";
+import { FormTabs } from "../components/FormTabs";
 import { HospitalNoticesEditor } from "../components/HospitalNoticesEditor";
 
 interface HospitalListItem {
@@ -57,6 +60,8 @@ const EMPTY: HospitalProfileInput = {
   keywords: [],
   treatment_items: [],
   opening_hours: null,
+  tagline: "",
+  detail_blocks: [],
   verified: false,
   booking_url: "",
 };
@@ -93,18 +98,7 @@ export default function AdminHospitalProfiles() {
     onSuccess: () => qc.invalidateQueries({ queryKey: ["admin", "hospitalProfiles"] }),
   });
 
-  const bannerUpload = useMutation({
-    mutationFn: (file: File) => uploadHospitalImage(file),
-    onSuccess: ({ url }) => setForm((f) => ({ ...f, banner_image_url: url })),
-    onError: (e: any) => alert(e?.message ?? "업로드 실패"),
-  });
 
-  const galleryUpload = useMutation({
-    mutationFn: (file: File) => uploadHospitalImage(file),
-    onSuccess: ({ url }) =>
-      setForm((f) => ({ ...f, images: [...(f.images ?? []), url] })),
-    onError: (e: any) => alert(e?.message ?? "업로드 실패"),
-  });
 
   const thumbUpload = useMutation({
     mutationFn: (file: File) => uploadHospitalImage(file),
@@ -133,6 +127,8 @@ export default function AdminHospitalProfiles() {
       keywords: h.keywords ?? [],
       treatment_items: h.treatment_items ?? [],
       opening_hours: h.opening_hours ?? null,
+      tagline: h.tagline ?? "",
+      detail_blocks: h.detail_blocks ?? [],
       verified: h.verified ?? false,
       booking_url: h.booking_url ?? "",
     });
@@ -159,142 +155,148 @@ export default function AdminHospitalProfiles() {
 
       <div style={card}>
         <h2>{editingId ? "프로필 수정" : "새 프로필"}</h2>
-        <Field label="카카오 place id (필수, 앱 검색 결과의 병원 id)">
-          <input value={form.kakao_place_id} onChange={set("kakao_place_id")} style={inp} />
-        </Field>
-        <Field label="병원명">
-          <input value={form.name} onChange={set("name")} style={inp} />
-        </Field>
-        <Field label="상세설명">
-          <textarea
-            value={form.description}
-            onChange={set("description")}
-            style={{ ...inp, height: 160 }}
-          />
-        </Field>
-
-        <Field label="배너 이미지">
-          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-            <input
-              value={form.banner_image_url ?? ""}
-              onChange={set("banner_image_url")}
-              style={{ ...inp, flex: 1 }}
-              placeholder="파일 업로드 또는 URL"
-            />
-            <UploadButton pending={bannerUpload.isPending} onFile={(f) => bannerUpload.mutate(f)} />
-          </div>
-          {form.banner_image_url ? (
-            <img src={form.banner_image_url} alt="" style={thumb} />
-          ) : null}
-        </Field>
-
-        <Field label="상세 이미지 (여러 장)">
-          <UploadButton pending={galleryUpload.isPending} onFile={(f) => galleryUpload.mutate(f)} />
-          <div style={{ display: "flex", flexWrap: "wrap", gap: 8, marginTop: 8 }}>
-            {(form.images ?? []).map((url, i) => (
-              <div key={i} style={{ position: "relative" }}>
-                <img src={url} alt="" style={{ ...thumb, marginTop: 0 }} />
-                <button
-                  type="button"
-                  onClick={() =>
-                    setForm((f) => ({
-                      ...f,
-                      images: (f.images ?? []).filter((_, idx) => idx !== i),
-                    }))
-                  }
-                  style={removeBtn}
-                >
-                  ×
-                </button>
-              </div>
-            ))}
-          </div>
-        </Field>
-
-        <Field label="썸네일 이미지 (리스트 카드용)">
-          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-            <input
-              value={form.thumbnail_url ?? ""}
-              onChange={set("thumbnail_url")}
-              style={{ ...inp, flex: 1 }}
-              placeholder="파일 업로드 또는 URL"
-            />
-            <UploadButton pending={thumbUpload.isPending} onFile={(f) => thumbUpload.mutate(f)} />
-          </div>
-          {form.thumbnail_url ? <img src={form.thumbnail_url} alt="" style={thumb} /> : null}
-        </Field>
-
-        <Field label="키워드 태그 (리스트 카드에 노출)">
-          <KeywordsEditor
-            value={form.keywords ?? []}
-            onChange={(keywords) => setForm((f) => ({ ...f, keywords }))}
-          />
-        </Field>
-
-        <Field label="병원 소식 (공지·이벤트)">
-          <HospitalNoticesEditor profileId={editingId} />
-        </Field>
-
-        <Field label="진료시간">
-          <OpeningHoursEditor
-            value={form.opening_hours ?? null}
-            onChange={(opening_hours) => setForm((f) => ({ ...f, opening_hours }))}
-          />
-        </Field>
-
-        <Field label="치료항목 (카테고리별 가격·안내)">
-          <TreatmentItemsEditor
-            value={form.treatment_items ?? []}
-            onChange={(treatment_items) => setForm((f) => ({ ...f, treatment_items }))}
-          />
-        </Field>
-
-        <Field label="예약 링크 (선택)">
-          <input value={form.booking_url ?? ""} onChange={set("booking_url")} style={inp} placeholder="https://" />
-        </Field>
-
-        <div style={{ display: "flex", gap: 12 }}>
-          <Field label="내부 병원 연결 (리뷰 자격 판정)">
-            <select
-              value={form.hospital_id ?? ""}
-              onChange={(e) => setForm((f) => ({ ...f, hospital_id: e.target.value || null }))}
-              style={inp}
-            >
-              <option value="">연결 안 함 (리뷰 비활성)</option>
-              {hospitalsQuery.data?.map((h) => (
-                <option key={h.id} value={h.id}>
-                  {h.name}
-                </option>
-              ))}
-            </select>
-          </Field>
-          <Field label="인증 배지">
-            <label style={{ display: "flex", alignItems: "center", gap: 6, padding: "8px 0" }}>
-              <input
-                type="checkbox"
-                checked={!!form.verified}
-                onChange={(e) => setForm((f) => ({ ...f, verified: e.target.checked }))}
-              />
-              인증됨 표시
-            </label>
-          </Field>
-        </div>
-
-        <div style={{ display: "flex", gap: 12 }}>
-          <Field label="전화">
-            <input value={form.phone} onChange={set("phone")} style={inp} />
-          </Field>
-          <Field label="주소">
-            <input value={form.address} onChange={set("address")} style={inp} />
-          </Field>
-          <Field label="상태">
-            <select value={form.status} onChange={set("status")} style={inp}>
-              <option value="published">게시</option>
-              <option value="pending">승인대기</option>
-              <option value="draft">임시저장</option>
-            </select>
-          </Field>
-        </div>
+        <FormTabs
+          tabs={[
+            {
+              key: "basic",
+              label: "기본 정보",
+              content: (
+                <>
+                  <Field label="카카오 place id (필수, 앱 검색 결과의 병원 id)">
+                    <input value={form.kakao_place_id} onChange={set("kakao_place_id")} style={inp} />
+                  </Field>
+                  <Field label="병원명">
+                    <input value={form.name} onChange={set("name")} style={inp} />
+                  </Field>
+                  <Field label="한 줄 소개 (리스트 카드·상세 상단)">
+                    <input
+                      value={form.tagline ?? ""}
+                      onChange={set("tagline")}
+                      style={inp}
+                      placeholder="예: 드림렌즈·아트로핀 전문 소아근시 클리닉"
+                      maxLength={120}
+                    />
+                  </Field>
+                  <Field label="키워드 태그 (리스트 카드에 노출)">
+                    <KeywordsEditor
+                      value={form.keywords ?? []}
+                      onChange={(keywords) => setForm((f) => ({ ...f, keywords }))}
+                    />
+                  </Field>
+                  <Field label="썸네일 이미지 (리스트 카드용)">
+                    <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                      <input
+                        value={form.thumbnail_url ?? ""}
+                        onChange={set("thumbnail_url")}
+                        style={{ ...inp, flex: 1 }}
+                        placeholder="파일 업로드 또는 URL"
+                      />
+                      <UploadButton pending={thumbUpload.isPending} onFile={(f) => thumbUpload.mutate(f)} />
+                    </div>
+                    {form.thumbnail_url ? <img src={form.thumbnail_url} alt="" style={thumb} /> : null}
+                  </Field>
+                  <div style={{ display: "flex", gap: 12 }}>
+                    <Field label="전화">
+                      <input value={form.phone} onChange={set("phone")} style={inp} />
+                    </Field>
+                    <Field label="주소">
+                      <input value={form.address} onChange={set("address")} style={inp} />
+                    </Field>
+                  </div>
+                  <Field label="예약 링크 (선택)">
+                    <input value={form.booking_url ?? ""} onChange={set("booking_url")} style={inp} placeholder="https://" />
+                  </Field>
+                </>
+              ),
+            },
+            {
+              key: "banner",
+              label: "배너 사진",
+              content: (
+                <BannerImagesEditor
+                  value={form.images ?? []}
+                  onChange={(images) => setForm((f) => ({ ...f, images }))}
+                  upload={uploadHospitalImages}
+                />
+              ),
+            },
+            {
+              key: "detail",
+              label: "상세 설명",
+              content: (
+                <DetailBlocksEditor
+                  value={form.detail_blocks ?? []}
+                  onChange={(detail_blocks) => setForm((f) => ({ ...f, detail_blocks }))}
+                  upload={uploadHospitalImages}
+                />
+              ),
+            },
+            {
+              key: "hours",
+              label: "진료시간",
+              content: (
+                <OpeningHoursEditor
+                  value={form.opening_hours ?? null}
+                  onChange={(opening_hours) => setForm((f) => ({ ...f, opening_hours }))}
+                />
+              ),
+            },
+            {
+              key: "treatments",
+              label: "치료항목",
+              content: (
+                <TreatmentItemsEditor
+                  value={form.treatment_items ?? []}
+                  onChange={(treatment_items) => setForm((f) => ({ ...f, treatment_items }))}
+                />
+              ),
+            },
+            {
+              key: "notices",
+              label: "소식",
+              content: <HospitalNoticesEditor profileId={editingId} />,
+            },
+            {
+              key: "admin",
+              label: "관리자 설정",
+              content: (
+                <>
+                  <Field label="내부 병원 연결 (리뷰 자격 · eyelog 연동 배지)">
+                    <select
+                      value={form.hospital_id ?? ""}
+                      onChange={(e) => setForm((f) => ({ ...f, hospital_id: e.target.value || null }))}
+                      style={inp}
+                    >
+                      <option value="">연결 안 함 (리뷰 비활성)</option>
+                      {hospitalsQuery.data?.map((h) => (
+                        <option key={h.id} value={h.id}>
+                          {h.name}
+                        </option>
+                      ))}
+                    </select>
+                  </Field>
+                  <Field label="인증 배지">
+                    <label style={{ display: "flex", alignItems: "center", gap: 6, padding: "8px 0" }}>
+                      <input
+                        type="checkbox"
+                        checked={!!form.verified}
+                        onChange={(e) => setForm((f) => ({ ...f, verified: e.target.checked }))}
+                      />
+                      인증됨 표시
+                    </label>
+                  </Field>
+                  <Field label="상태">
+                    <select value={form.status} onChange={set("status")} style={inp}>
+                      <option value="published">게시</option>
+                      <option value="pending">승인대기</option>
+                      <option value="draft">임시저장</option>
+                    </select>
+                  </Field>
+                </>
+              ),
+            },
+          ]}
+        />
 
         <div style={{ display: "flex", gap: 8, marginTop: 8, alignItems: "center" }}>
           <PrimaryButton onClick={() => canSave && saveMutation.mutate()}>
@@ -426,19 +428,6 @@ const thumb: CSSProperties = {
   maxHeight: 120,
   borderRadius: 8,
   display: "block",
-};
-const removeBtn: CSSProperties = {
-  position: "absolute",
-  top: 2,
-  right: 2,
-  width: 22,
-  height: 22,
-  borderRadius: 11,
-  border: "none",
-  background: "rgba(0,0,0,0.6)",
-  color: "#fff",
-  cursor: "pointer",
-  lineHeight: "20px",
 };
 const previewBtn: CSSProperties = {
   display: "inline-block",

--- a/src/routes/admin_hospital_profiles.tsx
+++ b/src/routes/admin_hospital_profiles.tsx
@@ -10,6 +10,7 @@ import {
   updateHospitalProfile,
   uploadHospitalImage,
   uploadHospitalImages,
+  normaliseProfileUrls,
   type HospitalProfile,
   type HospitalProfileInput,
 } from "../api/hospitalProfile";
@@ -85,7 +86,9 @@ export default function AdminHospitalProfiles() {
 
   const saveMutation = useMutation({
     mutationFn: () =>
-      editingId ? updateHospitalProfile(editingId, form) : createHospitalProfile(form),
+      editingId
+        ? updateHospitalProfile(editingId, normaliseProfileUrls(form))
+        : createHospitalProfile(normaliseProfileUrls(form)),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["admin", "hospitalProfiles"] });
       reset();

--- a/src/routes/partner/PartnerProfile.tsx
+++ b/src/routes/partner/PartnerProfile.tsx
@@ -12,6 +12,7 @@ import {
   type PartnerMe,
   type PartnerProfileInput,
 } from "../../api/partner";
+import { normaliseProfileUrls } from "../../api/hospitalProfile";
 import {
   KeywordsEditor,
   OpeningHoursEditor,
@@ -90,7 +91,7 @@ export default function PartnerProfile() {
     setMsg(null);
     setSaving(true);
     try {
-      await savePartnerProfile(form);
+      await savePartnerProfile(normaliseProfileUrls(form));
       setMsg("저장되었습니다.");
     } catch (e: any) {
       setMsg(e?.message ?? "저장 실패");

--- a/src/routes/partner/PartnerProfile.tsx
+++ b/src/routes/partner/PartnerProfile.tsx
@@ -8,6 +8,7 @@ import {
   partnerMe,
   savePartnerProfile,
   uploadPartnerImage,
+  uploadPartnerImages,
   type PartnerMe,
   type PartnerProfileInput,
 } from "../../api/partner";
@@ -16,6 +17,9 @@ import {
   OpeningHoursEditor,
   TreatmentItemsEditor,
 } from "../../components/hospitalCardEditors";
+import { BannerImagesEditor, DetailBlocksEditor } from "../../components/HospitalContentEditors";
+import { FormTabs } from "../../components/FormTabs";
+import { PartnerNoticesEditor } from "../../components/PartnerNoticesEditor";
 
 const EMPTY: PartnerProfileInput = {
   kakao_place_id: "",
@@ -29,6 +33,8 @@ const EMPTY: PartnerProfileInput = {
   keywords: [],
   treatment_items: [],
   opening_hours: null,
+  tagline: "",
+  detail_blocks: [],
   booking_url: "",
 };
 
@@ -39,8 +45,6 @@ export default function PartnerProfile() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [msg, setMsg] = useState<string | null>(null);
-  const [bannerUploading, setBannerUploading] = useState(false);
-  const [galleryUploading, setGalleryUploading] = useState(false);
   const [thumbUploading, setThumbUploading] = useState(false);
 
   useEffect(() => {
@@ -64,6 +68,8 @@ export default function PartnerProfile() {
             keywords: p.keywords ?? [],
             treatment_items: p.treatment_items ?? [],
             opening_hours: p.opening_hours ?? null,
+            tagline: p.tagline ?? "",
+            detail_blocks: p.detail_blocks ?? [],
             booking_url: p.booking_url ?? "",
           });
         } else {
@@ -123,122 +129,117 @@ export default function PartnerProfile() {
       )}
 
       <div style={card}>
-        <Field label="카카오 place id (앱 검색 결과의 내 병원 id)">
-          <input value={form.kakao_place_id} onChange={set("kakao_place_id")} style={inp} />
-        </Field>
-        <Field label="병원명">
-          <input value={form.name} onChange={set("name")} style={inp} />
-        </Field>
-        <Field label="상세설명">
-          <textarea value={form.description} onChange={set("description")} style={{ ...inp, height: 160 }} />
-        </Field>
-
-        <Field label="배너 이미지">
-          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-            <input value={form.banner_image_url ?? ""} onChange={set("banner_image_url")} style={{ ...inp, flex: 1 }} placeholder="파일 업로드 또는 URL" />
-            <UploadBtn
-              busy={bannerUploading}
-              onFile={async (f) => {
-                setBannerUploading(true);
-                try {
-                  const { url } = await uploadPartnerImage(f);
-                  setForm((s) => ({ ...s, banner_image_url: url }));
-                } catch (e: any) {
-                  alert(e?.message ?? "업로드 실패");
-                } finally {
-                  setBannerUploading(false);
-                }
-              }}
-            />
-          </div>
-          {form.banner_image_url ? <img src={form.banner_image_url} alt="" style={thumb} /> : null}
-        </Field>
-
-        <Field label="상세 이미지 (여러 장)">
-          <UploadBtn
-            busy={galleryUploading}
-            onFile={async (f) => {
-              setGalleryUploading(true);
-              try {
-                const { url } = await uploadPartnerImage(f);
-                setForm((s) => ({ ...s, images: [...(s.images ?? []), url] }));
-              } catch (e: any) {
-                alert(e?.message ?? "업로드 실패");
-              } finally {
-                setGalleryUploading(false);
-              }
-            }}
-          />
-          <div style={{ display: "flex", flexWrap: "wrap", gap: 8, marginTop: 8 }}>
-            {(form.images ?? []).map((url, i) => (
-              <div key={i} style={{ position: "relative" }}>
-                <img src={url} alt="" style={{ ...thumb, marginTop: 0 }} />
-                <button
-                  type="button"
-                  style={removeBtn}
-                  onClick={() => setForm((s) => ({ ...s, images: (s.images ?? []).filter((_, idx) => idx !== i) }))}
-                >
-                  ×
-                </button>
-              </div>
-            ))}
-          </div>
-        </Field>
-
-        <Field label="썸네일 이미지 (리스트 카드용)">
-          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-            <input value={form.thumbnail_url ?? ""} onChange={set("thumbnail_url")} style={{ ...inp, flex: 1 }} placeholder="파일 업로드 또는 URL" />
-            <UploadBtn
-              busy={thumbUploading}
-              onFile={async (f) => {
-                setThumbUploading(true);
-                try {
-                  const { url } = await uploadPartnerImage(f);
-                  setForm((s) => ({ ...s, thumbnail_url: url }));
-                } catch (e: any) {
-                  alert(e?.message ?? "업로드 실패");
-                } finally {
-                  setThumbUploading(false);
-                }
-              }}
-            />
-          </div>
-          {form.thumbnail_url ? <img src={form.thumbnail_url} alt="" style={thumb} /> : null}
-        </Field>
-
-        <Field label="키워드 태그 (리스트 카드에 노출)">
-          <KeywordsEditor
-            value={form.keywords ?? []}
-            onChange={(keywords) => setForm((s) => ({ ...s, keywords }))}
-          />
-        </Field>
-
-        <Field label="진료시간">
-          <OpeningHoursEditor
-            value={form.opening_hours ?? null}
-            onChange={(opening_hours) => setForm((s) => ({ ...s, opening_hours }))}
-          />
-        </Field>
-
-        <Field label="치료항목 (카테고리별 가격·안내)">
-          <TreatmentItemsEditor
-            value={form.treatment_items ?? []}
-            onChange={(treatment_items) => setForm((s) => ({ ...s, treatment_items }))}
-          />
-        </Field>
-
-        <Field label="예약 링크 (선택)">
-          <input value={form.booking_url ?? ""} onChange={set("booking_url")} style={inp} placeholder="https://" />
-        </Field>
-
-        <div style={{ display: "flex", gap: 12 }}>
-          <Field label="전화">
-            <input value={form.phone} onChange={set("phone")} style={inp} />
-          </Field>
-          <Field label="주소">
-            <input value={form.address} onChange={set("address")} style={inp} />
-          </Field>
-        </div>
+        <FormTabs
+          tabs={[
+            {
+              key: "basic",
+              label: "기본 정보",
+              content: (
+                <>
+                  <Field label="카카오 place id (앱 검색 결과의 내 병원 id)">
+                    <input value={form.kakao_place_id} onChange={set("kakao_place_id")} style={inp} />
+                  </Field>
+                  <Field label="병원명">
+                    <input value={form.name} onChange={set("name")} style={inp} />
+                  </Field>
+                  <Field label="한 줄 소개 (리스트 카드·상세 상단)">
+                    <input
+                      value={form.tagline ?? ""}
+                      onChange={set("tagline")}
+                      style={inp}
+                      placeholder="예: 드림렌즈·아트로핀 전문 소아근시 클리닉"
+                      maxLength={120}
+                    />
+                  </Field>
+                  <Field label="키워드 태그 (리스트 카드에 노출)">
+                    <KeywordsEditor
+                      value={form.keywords ?? []}
+                      onChange={(keywords) => setForm((s) => ({ ...s, keywords }))}
+                    />
+                  </Field>
+                  <Field label="썸네일 이미지 (리스트 카드용)">
+                    <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                      <input value={form.thumbnail_url ?? ""} onChange={set("thumbnail_url")} style={{ ...inp, flex: 1 }} placeholder="파일 업로드 또는 URL" />
+                      <UploadBtn
+                        busy={thumbUploading}
+                        onFile={async (f) => {
+                          setThumbUploading(true);
+                          try {
+                            const { url } = await uploadPartnerImage(f);
+                            setForm((s) => ({ ...s, thumbnail_url: url }));
+                          } catch (e: any) {
+                            alert(e?.message ?? "업로드 실패");
+                          } finally {
+                            setThumbUploading(false);
+                          }
+                        }}
+                      />
+                    </div>
+                    {form.thumbnail_url ? <img src={form.thumbnail_url} alt="" style={thumb} /> : null}
+                  </Field>
+                  <div style={{ display: "flex", gap: 12 }}>
+                    <Field label="전화">
+                      <input value={form.phone} onChange={set("phone")} style={inp} />
+                    </Field>
+                    <Field label="주소">
+                      <input value={form.address} onChange={set("address")} style={inp} />
+                    </Field>
+                  </div>
+                  <Field label="예약 링크 (선택)">
+                    <input value={form.booking_url ?? ""} onChange={set("booking_url")} style={inp} placeholder="https://" />
+                  </Field>
+                </>
+              ),
+            },
+            {
+              key: "banner",
+              label: "배너 사진",
+              content: (
+                <BannerImagesEditor
+                  value={form.images ?? []}
+                  onChange={(images) => setForm((s) => ({ ...s, images }))}
+                  upload={uploadPartnerImages}
+                />
+              ),
+            },
+            {
+              key: "detail",
+              label: "상세 설명",
+              content: (
+                <DetailBlocksEditor
+                  value={form.detail_blocks ?? []}
+                  onChange={(detail_blocks) => setForm((s) => ({ ...s, detail_blocks }))}
+                  upload={uploadPartnerImages}
+                />
+              ),
+            },
+            {
+              key: "hours",
+              label: "진료시간",
+              content: (
+                <OpeningHoursEditor
+                  value={form.opening_hours ?? null}
+                  onChange={(opening_hours) => setForm((s) => ({ ...s, opening_hours }))}
+                />
+              ),
+            },
+            {
+              key: "treatments",
+              label: "치료항목",
+              content: (
+                <TreatmentItemsEditor
+                  value={form.treatment_items ?? []}
+                  onChange={(treatment_items) => setForm((s) => ({ ...s, treatment_items }))}
+                />
+              ),
+            },
+            {
+              key: "notices",
+              label: "소식",
+              content: <PartnerNoticesEditor />,
+            },
+          ]}
+        />
 
         {msg && <p style={{ fontSize: 13, color: msg.includes("저장되") ? "#0d7d6f" : "#b3261e" }}>{msg}</p>}
         <button style={{ ...saveBtn, opacity: canSave && !saving ? 1 : 0.5 }} disabled={!canSave || saving} onClick={save}>
@@ -302,18 +303,6 @@ const uploadBtn: CSSProperties = {
   whiteSpace: "nowrap",
 };
 const thumb: CSSProperties = { marginTop: 8, maxWidth: 200, maxHeight: 120, borderRadius: 8, display: "block" };
-const removeBtn: CSSProperties = {
-  position: "absolute",
-  top: 2,
-  right: 2,
-  width: 22,
-  height: 22,
-  borderRadius: 11,
-  border: "none",
-  background: "rgba(0,0,0,0.6)",
-  color: "#fff",
-  cursor: "pointer",
-};
 const saveBtn: CSSProperties = {
   padding: "12px 20px",
   border: "none",


### PR DESCRIPTION
파트너 화면을 실제로 써보고 나온 요청들.

## 탭 분리

한 화면에 기본정보·사진·진료시간·가격·소식이 세로로 쌓여 있어서, 병원 하나를 등록하려면 **지금 안 하는 것들을 전부 스크롤해 지나가야** 했다.

```
기본 정보 | 배너 사진 | 상세 설명 | 진료시간 | 치료항목 | 소식 | (관리자 설정)
```

모든 탭은 **마운트된 채로** 두어 저장 한 번에 전체가 넘어간다 — 탭을 옮길 때마다 저장을 요구하면 더 나쁘다.

## 배너 사진

- **여러 장 한 번에 업로드**. 한 장씩 고르는 게 등록에서 제일 느린 구간인데 병원은 사진을 묶음으로 갖고 있다
- 순서 바꾸기 / 삭제, **첫 장에 "대표" 표시**
- **최대 10장** — 넘치게 고르면 몇 장만 추가한다고 알린다

## 상세 설명

**글과 사진을 원하는 순서로 배치하는 블록 편집기.** 텍스트 한 칸과 평평한 갤러리로는 "이건 이런 시술이고, 이렇게 생겼습니다"를 쓸 수 없다.

## 한 줄 소개

`tagline` 추가. 지금까지 "상세설명" 하나가 **카드의 소개문과 상세의 본문을 겸하고** 있었다.

## 파트너 소식

파트너 화면에도 소식 등록을 붙였다. API가 로그인한 파트너로 프로필을 되찾으므로 **이 컴포넌트는 프로필 id를 아예 다루지 않는다** — 남의 병원 소식에 손댈 경로가 없다.

프로필 저장 전에 소식을 쓰면 409가 오는데, 이를 "프로필을 먼저 저장하세요"로 옮겨 보여준다.

## 검증

`tsc -b` 통과. (이 저장소는 `tsc --noEmit`이 아무 파일도 읽지 않으므로 `tsc -b`로 확인해야 한다.)

## 의존

myopiaBackend #43