### PR TITLE
fix(admin): 키워드 입력이 한글 조합 때문에 두 번 들어가던 문제

### DIFF
--- a/src/components/hospitalCardEditors.tsx
+++ b/src/components/hospitalCardEditors.tsx
@@ -33,6 +33,11 @@ export function KeywordsEditor({
           value={draft}
           onChange={(e) => setDraft(e.target.value)}
           onKeyDown={(e) => {
+            // Enter while a Korean IME is still composing means "confirm this
+            // syllable", not "submit". Without this guard one Enter fires twice
+            // — once for the composition, once for the key — and "라식" is added
+            // followed by the leftover "식".
+            if (e.nativeEvent.isComposing) return;
             if (e.key === "Enter") {
               e.preventDefault();
               add();


### PR DESCRIPTION
## 증상

키워드에 "라식"을 입력하고 Enter를 치면 **`라식`과 `식`이 둘 다** 추가된다.

## 원인

한글 IME가 조합 중일 때의 Enter는 **"이 글자를 확정"** 이지 "제출"이 아니다. 그대로 처리하면 Enter 한 번에 핸들러가 두 번 돌아, 먼저 `라식`이 들어가고 남은 조합 문자 `식`이 또 들어간다.

한글·일본어·중국어 입력에서만 나타나므로 영문 테스트로는 드러나지 않는다.

## 수정

`e.nativeEvent.isComposing`이면 무시한다.

## 검증

`tsc -b` 통과.