### PR TITLE
feat(admin): 카카오 검색으로 병원 선택, 썸네일 자동, 저장 메시지 정리

### DIFF
--- a/src/api/hospitalProfile.ts
+++ b/src/api/hospitalProfile.ts
@@ -225,3 +225,12 @@ export function normaliseProfileUrls<T extends object>(form: T): T {
   }
   return out as T;
 }
+
+/** Kakao place search for the admin profile form. */
+export function searchAdminPlaces(q: string): Promise<{
+  places: import("../components/PlacePicker").PlaceResult[];
+}> {
+  return jsonFetchWithSession(
+    `${API_ROOT}/hospital-profile/place-search?q=${encodeURIComponent(q)}`,
+  );
+}

--- a/src/api/partner.ts
+++ b/src/api/partner.ts
@@ -200,3 +200,10 @@ export function updatePartnerNotice(
 export function deletePartnerNotice(id: string): Promise<void> {
   return partnerFetch(`/partner/notices/${id}`, { method: "DELETE" });
 }
+
+/** Kakao place search, so a clinic picks itself instead of typing an id. */
+export function searchPartnerPlaces(q: string): Promise<{
+  places: import("../components/PlacePicker").PlaceResult[];
+}> {
+  return partnerFetch(`/partner/place-search?q=${encodeURIComponent(q)}`);
+}

--- a/src/components/PlacePicker.tsx
+++ b/src/components/PlacePicker.tsx
@@ -1,0 +1,142 @@
+import { useState, type CSSProperties } from "react";
+
+export interface PlaceResult {
+  id: string;
+  name: string;
+  category: string;
+  phone: string | null;
+  address: string | null;
+  roadAddress: string | null;
+}
+
+/**
+ * Find a clinic on Kakao by name and pick it.
+ *
+ * The profile is keyed by Kakao place id. Asking clinic staff to look that
+ * number up and type it is not a workable onboarding step — they get it wrong,
+ * the save succeeds anyway, and nothing ever appears in the app with no hint as
+ * to why. Picking from search results removes the id from the human's hands
+ * entirely, and fills in the phone and address while it's at it.
+ */
+export function PlacePicker({
+  search,
+  onPick,
+  currentId,
+}: {
+  search: (q: string) => Promise<{ places: PlaceResult[] }>;
+  onPick: (p: PlaceResult) => void;
+  currentId?: string;
+}) {
+  const [q, setQ] = useState("");
+  const [rows, setRows] = useState<PlaceResult[] | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const run = async () => {
+    const query = q.trim();
+    if (query.length < 2) {
+      setErr("두 글자 이상 입력해 주세요.");
+      return;
+    }
+    setBusy(true);
+    setErr(null);
+    try {
+      const r = await search(query);
+      setRows(r.places);
+      if (r.places.length === 0) setErr("검색 결과가 없습니다.");
+    } catch (e: any) {
+      setErr(e?.message ?? "검색에 실패했습니다.");
+      setRows(null);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div>
+      <div style={{ display: "flex", gap: 8 }}>
+        <input
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          onKeyDown={(e) => {
+            // Korean IME: Enter during composition confirms the syllable.
+            if (e.nativeEvent.isComposing) return;
+            if (e.key === "Enter") {
+              e.preventDefault();
+              void run();
+            }
+          }}
+          placeholder="병원 이름으로 검색 (예: 누네안과병원 서울)"
+          style={{ ...inp, flex: 1 }}
+        />
+        <button type="button" onClick={() => void run()} disabled={busy} style={btn}>
+          {busy ? "검색 중…" : "검색"}
+        </button>
+      </div>
+
+      {err && <p style={{ color: "#b3261e", fontSize: 13, margin: "8px 0 0" }}>{err}</p>}
+
+      {rows && rows.length > 0 && (
+        <div style={list}>
+          {rows.map((p) => {
+            const picked = p.id === currentId;
+            return (
+              <button
+                key={p.id}
+                type="button"
+                onClick={() => onPick(p)}
+                style={{
+                  ...row,
+                  background: picked ? "#eef4ff" : "#fff",
+                  borderColor: picked ? "#0d47a1" : "#e5e7eb",
+                }}
+              >
+                <div style={{ fontWeight: 700 }}>
+                  {p.name}
+                  {picked && <span style={{ color: "#0d47a1", fontSize: 12 }}> · 선택됨</span>}
+                </div>
+                <div style={{ color: "#6b7280", fontSize: 12.5 }}>
+                  {p.roadAddress || p.address}
+                  {p.phone ? ` · ${p.phone}` : ""}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const inp: CSSProperties = {
+  padding: "8px 10px",
+  border: "1px solid #ddd",
+  borderRadius: 8,
+  fontSize: 14,
+};
+const btn: CSSProperties = {
+  padding: "8px 16px",
+  borderRadius: 8,
+  border: "1px solid #0d47a1",
+  background: "#0d47a1",
+  color: "#fff",
+  cursor: "pointer",
+  fontSize: 13,
+  whiteSpace: "nowrap",
+};
+const list: CSSProperties = {
+  display: "grid",
+  gap: 6,
+  marginTop: 8,
+  maxHeight: 260,
+  overflowY: "auto",
+};
+const row: CSSProperties = {
+  textAlign: "left",
+  border: "1px solid #e5e7eb",
+  borderRadius: 8,
+  padding: "10px 12px",
+  cursor: "pointer",
+  display: "grid",
+  gap: 2,
+};

--- a/src/routes/admin_hospital_profiles.tsx
+++ b/src/routes/admin_hospital_profiles.tsx
@@ -8,8 +8,8 @@ import {
   deleteHospitalProfile,
   listHospitalProfiles,
   updateHospitalProfile,
-  uploadHospitalImage,
   uploadHospitalImages,
+  searchAdminPlaces,
   normaliseProfileUrls,
   type HospitalProfile,
   type HospitalProfileInput,
@@ -22,6 +22,7 @@ import {
 } from "../components/hospitalCardEditors";
 import { BannerImagesEditor, DetailBlocksEditor } from "../components/HospitalContentEditors";
 import { FormTabs } from "../components/FormTabs";
+import { PlacePicker } from "../components/PlacePicker";
 import { HospitalNoticesEditor } from "../components/HospitalNoticesEditor";
 
 interface HospitalListItem {
@@ -103,11 +104,6 @@ export default function AdminHospitalProfiles() {
 
 
 
-  const thumbUpload = useMutation({
-    mutationFn: (file: File) => uploadHospitalImage(file),
-    onSuccess: ({ url }) => setForm((f) => ({ ...f, thumbnail_url: url })),
-    onError: (e: any) => alert(e?.message ?? "업로드 실패"),
-  });
 
   function reset() {
     setEditingId(null);
@@ -165,8 +161,29 @@ export default function AdminHospitalProfiles() {
               label: "기본 정보",
               content: (
                 <>
-                  <Field label="카카오 place id (필수, 앱 검색 결과의 병원 id)">
-                    <input value={form.kakao_place_id} onChange={set("kakao_place_id")} style={inp} />
+                  <Field label="병원 찾기 (카카오맵 검색)">
+                    <PlacePicker
+                      search={searchAdminPlaces}
+                      currentId={form.kakao_place_id}
+                      onPick={(pl) =>
+                        setForm((f) => ({
+                          ...f,
+                          kakao_place_id: pl.id,
+                          name: pl.name,
+                          phone: pl.phone ?? f.phone,
+                          address: pl.roadAddress ?? pl.address ?? f.address,
+                        }))
+                      }
+                    />
+                    {form.kakao_place_id ? (
+                      <p style={{ color: "#0d7d6f", fontSize: 13, margin: "8px 0 0" }}>
+                        선택됨: {form.name} (place id {form.kakao_place_id})
+                      </p>
+                    ) : (
+                      <p style={{ color: "#6b7280", fontSize: 12, margin: "8px 0 0" }}>
+                        검색해서 병원을 선택하면 병원명·전화·주소가 자동으로 채워집니다.
+                      </p>
+                    )}
                   </Field>
                   <Field label="병원명">
                     <input value={form.name} onChange={set("name")} style={inp} />
@@ -185,18 +202,6 @@ export default function AdminHospitalProfiles() {
                       value={form.keywords ?? []}
                       onChange={(keywords) => setForm((f) => ({ ...f, keywords }))}
                     />
-                  </Field>
-                  <Field label="썸네일 이미지 (리스트 카드용)">
-                    <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-                      <input
-                        value={form.thumbnail_url ?? ""}
-                        onChange={set("thumbnail_url")}
-                        style={{ ...inp, flex: 1 }}
-                        placeholder="파일 업로드 또는 URL"
-                      />
-                      <UploadButton pending={thumbUpload.isPending} onFile={(f) => thumbUpload.mutate(f)} />
-                    </div>
-                    {form.thumbnail_url ? <img src={form.thumbnail_url} alt="" style={thumb} /> : null}
                   </Field>
                   <div style={{ display: "flex", gap: 12 }}>
                     <Field label="전화">
@@ -372,29 +377,6 @@ export default function AdminHospitalProfiles() {
   );
 }
 
-function UploadButton({ pending, onFile }: { pending: boolean; onFile: (f: File) => void }) {
-  return (
-    <label
-      style={{
-        ...uploadBtn,
-        opacity: pending ? 0.6 : 1,
-        pointerEvents: pending ? "none" : "auto",
-      }}
-    >
-      {pending ? "업로드 중…" : "파일 선택"}
-      <input
-        type="file"
-        accept="image/*"
-        style={{ display: "none" }}
-        onChange={(e) => {
-          const file = e.target.files?.[0];
-          if (file) onFile(file);
-          e.target.value = "";
-        }}
-      />
-    </label>
-  );
-}
 
 function Field({ label, children }: { label: string; children: ReactNode }) {
   return (
@@ -414,23 +396,6 @@ const inp: CSSProperties = {
   border: "1px solid #ccc",
   borderRadius: 6,
   boxSizing: "border-box",
-};
-const uploadBtn: CSSProperties = {
-  flexShrink: 0,
-  padding: "8px 14px",
-  border: "1px solid #ccc",
-  borderRadius: 6,
-  background: "#f3f4f6",
-  cursor: "pointer",
-  fontSize: 13,
-  whiteSpace: "nowrap",
-};
-const thumb: CSSProperties = {
-  marginTop: 8,
-  maxWidth: 200,
-  maxHeight: 120,
-  borderRadius: 8,
-  display: "block",
 };
 const previewBtn: CSSProperties = {
   display: "inline-block",

--- a/src/routes/partner/PartnerProfile.tsx
+++ b/src/routes/partner/PartnerProfile.tsx
@@ -7,8 +7,8 @@ import {
   getPartnerToken,
   partnerMe,
   savePartnerProfile,
-  uploadPartnerImage,
   uploadPartnerImages,
+  searchPartnerPlaces,
   type PartnerMe,
   type PartnerProfileInput,
 } from "../../api/partner";
@@ -20,6 +20,7 @@ import {
 } from "../../components/hospitalCardEditors";
 import { BannerImagesEditor, DetailBlocksEditor } from "../../components/HospitalContentEditors";
 import { FormTabs } from "../../components/FormTabs";
+import { PlacePicker } from "../../components/PlacePicker";
 import { PartnerNoticesEditor } from "../../components/PartnerNoticesEditor";
 
 const EMPTY: PartnerProfileInput = {
@@ -46,7 +47,6 @@ export default function PartnerProfile() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [msg, setMsg] = useState<string | null>(null);
-  const [thumbUploading, setThumbUploading] = useState(false);
 
   useEffect(() => {
     if (!getPartnerToken()) {
@@ -93,6 +93,10 @@ export default function PartnerProfile() {
     try {
       await savePartnerProfile(normaliseProfileUrls(form));
       setMsg("저장되었습니다.");
+      // Clear it shortly after: the banner sits outside the tabs, so leaving it
+      // up made "저장되었습니다" follow the user into 배너 사진 as if that tab
+      // had just been saved.
+      window.setTimeout(() => setMsg(null), 2500);
     } catch (e: any) {
       setMsg(e?.message ?? "저장 실패");
     } finally {
@@ -137,8 +141,31 @@ export default function PartnerProfile() {
               label: "기본 정보",
               content: (
                 <>
-                  <Field label="카카오 place id (앱 검색 결과의 내 병원 id)">
-                    <input value={form.kakao_place_id} onChange={set("kakao_place_id")} style={inp} />
+                  <Field label="병원 찾기 (카카오맵 검색)">
+                    <PlacePicker
+                      search={searchPartnerPlaces}
+                      currentId={form.kakao_place_id}
+                      onPick={(pl) =>
+                        setForm((s) => ({
+                          ...s,
+                          kakao_place_id: pl.id,
+                          name: pl.name,
+                          // Prefilled from Kakao so the clinic doesn't retype
+                          // what the app already shows on the list card.
+                          phone: pl.phone ?? s.phone,
+                          address: pl.roadAddress ?? pl.address ?? s.address,
+                        }))
+                      }
+                    />
+                    {form.kakao_place_id ? (
+                      <p style={{ color: "#0d7d6f", fontSize: 13, margin: "8px 0 0" }}>
+                        선택됨: {form.name} (place id {form.kakao_place_id})
+                      </p>
+                    ) : (
+                      <p style={{ color: "#6b7280", fontSize: 12, margin: "8px 0 0" }}>
+                        검색해서 내 병원을 선택하면 병원명·전화·주소가 자동으로 채워집니다.
+                      </p>
+                    )}
                   </Field>
                   <Field label="병원명">
                     <input value={form.name} onChange={set("name")} style={inp} />
@@ -157,26 +184,6 @@ export default function PartnerProfile() {
                       value={form.keywords ?? []}
                       onChange={(keywords) => setForm((s) => ({ ...s, keywords }))}
                     />
-                  </Field>
-                  <Field label="썸네일 이미지 (리스트 카드용)">
-                    <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-                      <input value={form.thumbnail_url ?? ""} onChange={set("thumbnail_url")} style={{ ...inp, flex: 1 }} placeholder="파일 업로드 또는 URL" />
-                      <UploadBtn
-                        busy={thumbUploading}
-                        onFile={async (f) => {
-                          setThumbUploading(true);
-                          try {
-                            const { url } = await uploadPartnerImage(f);
-                            setForm((s) => ({ ...s, thumbnail_url: url }));
-                          } catch (e: any) {
-                            alert(e?.message ?? "업로드 실패");
-                          } finally {
-                            setThumbUploading(false);
-                          }
-                        }}
-                      />
-                    </div>
-                    {form.thumbnail_url ? <img src={form.thumbnail_url} alt="" style={thumb} /> : null}
                   </Field>
                   <div style={{ display: "flex", gap: 12 }}>
                     <Field label="전화">
@@ -251,23 +258,6 @@ export default function PartnerProfile() {
   );
 }
 
-function UploadBtn({ busy, onFile }: { busy: boolean; onFile: (f: File) => void }) {
-  return (
-    <label style={{ ...uploadBtn, opacity: busy ? 0.6 : 1, pointerEvents: busy ? "none" : "auto" }}>
-      {busy ? "업로드 중…" : "파일 선택"}
-      <input
-        type="file"
-        accept="image/*"
-        style={{ display: "none" }}
-        onChange={(e) => {
-          const f = e.target.files?.[0];
-          if (f) onFile(f);
-          e.target.value = "";
-        }}
-      />
-    </label>
-  );
-}
 
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (
@@ -292,29 +282,18 @@ function statusBox(status: string): CSSProperties {
 }
 
 const card: CSSProperties = { border: "1px solid #ddd", borderRadius: 8, padding: 16, marginTop: 12 };
-const inp: CSSProperties = { width: "100%", padding: 8, border: "1px solid #ccc", borderRadius: 6, boxSizing: "border-box" };
-const uploadBtn: CSSProperties = {
-  flexShrink: 0,
-  padding: "8px 14px",
-  border: "1px solid #ccc",
-  borderRadius: 6,
-  background: "#f3f4f6",
-  cursor: "pointer",
-  fontSize: 13,
-  whiteSpace: "nowrap",
-};
-const thumb: CSSProperties = { marginTop: 8, maxWidth: 200, maxHeight: 120, borderRadius: 8, display: "block" };
 const saveBtn: CSSProperties = {
-  padding: "12px 20px",
-  border: "none",
+  padding: "12px 24px",
   borderRadius: 8,
+  border: "none",
   background: "#0d47a1",
   color: "#fff",
   fontSize: 15,
   fontWeight: 700,
   cursor: "pointer",
-  marginTop: 8,
 };
+
+const inp: CSSProperties = { width: "100%", padding: 8, border: "1px solid #ccc", borderRadius: 6, boxSizing: "border-box" };
 const logout: CSSProperties = {
   padding: "6px 12px",
   border: "1px solid #ddd",


### PR DESCRIPTION
## place id 직접 입력을 없앴다

이름으로 검색해 고르면 **place id·병원명·전화·주소가 한 번에** 채워진다.

담당자가 번호를 잘못 넣어도 저장은 200으로 성공하고, 앱에는 아무것도 안 뜨는데 이유를 알 수 없었다 — 실제로 겪은 문제다. 사람이 그 번호를 다루지 않게 하는 것이 유일한 해결책이다.

## 썸네일 별도 등록 제거

없으면 배너 첫 장을 쓴다. "같은 사진을 두 번 올리지 않게" 를 UI를 더하는 대신 **입력을 하나 빼서** 해결했다.

## 저장 메시지

저장 배너가 탭 바깥에 있어서 `저장되었습니다` 가 다른 탭까지 따라다녔고, 마치 그 탭을 방금 저장한 것처럼 보였다. 잠시 뒤 지운다.

## 검증

`tsc -b` 통과. (이 저장소는 `tsc --noEmit` 이 아무 파일도 읽지 않는다.)

## 의존

myopiaBackend #45