### PR TITLE
fix(partner): 병원 선택 후 검색 결과 숨김, 탭 이동 시 저장 메시지 제거

### DIFF
--- a/src/components/FormTabs.tsx
+++ b/src/components/FormTabs.tsx
@@ -14,7 +14,15 @@ export interface FormTab {
  * everything you weren't doing. Every tab stays mounted so a single Save still
  * submits the whole form; hidden panels are only visually hidden.
  */
-export function FormTabs({ tabs }: { tabs: FormTab[] }) {
+export function FormTabs({
+  tabs,
+  onTabChange,
+}: {
+  tabs: FormTab[];
+  /** Fires when the user moves to another tab — used to drop a save banner
+   *  that would otherwise follow them into a tab they haven't saved. */
+  onTabChange?: () => void;
+}) {
   const [active, setActive] = useState(tabs[0]?.key);
 
   return (
@@ -26,7 +34,10 @@ export function FormTabs({ tabs }: { tabs: FormTab[] }) {
             <button
               key={t.key}
               type="button"
-              onClick={() => setActive(t.key)}
+              onClick={() => {
+                if (t.key !== active) onTabChange?.();
+                setActive(t.key);
+              }}
               style={{
                 ...tabBtn,
                 color: on ? "#0d47a1" : "#6b7280",

--- a/src/components/PlacePicker.tsx
+++ b/src/components/PlacePicker.tsx
@@ -84,7 +84,11 @@ export function PlacePicker({
               <button
                 key={p.id}
                 type="button"
-                onClick={() => onPick(p)}
+                onClick={() => {
+                  onPick(p);
+                  setRows(null);
+                  setQ("");
+                }}
                 style={{
                   ...row,
                   background: picked ? "#eef4ff" : "#fff",

--- a/src/routes/partner/PartnerProfile.tsx
+++ b/src/routes/partner/PartnerProfile.tsx
@@ -93,10 +93,6 @@ export default function PartnerProfile() {
     try {
       await savePartnerProfile(normaliseProfileUrls(form));
       setMsg("저장되었습니다.");
-      // Clear it shortly after: the banner sits outside the tabs, so leaving it
-      // up made "저장되었습니다" follow the user into 배너 사진 as if that tab
-      // had just been saved.
-      window.setTimeout(() => setMsg(null), 2500);
     } catch (e: any) {
       setMsg(e?.message ?? "저장 실패");
     } finally {
@@ -135,6 +131,9 @@ export default function PartnerProfile() {
 
       <div style={card}>
         <FormTabs
+          // The save banner sits outside the tabs, so leaving it up made
+          // "저장되었습니다" follow the user into a tab they hadn't saved.
+          onTabChange={() => setMsg(null)}
           tabs={[
             {
               key: "basic",


### PR DESCRIPTION
- 검색 결과에서 병원을 고르면 미리보기 리스트가 폼 위에 계속 남아 있던 문제 → 선택 시 결과와 검색어를 비움
- `저장되었습니다` 배너가 탭 밖에 있어 배너사진 탭으로 넘어가도 따라다니던 문제 → `FormTabs`에 `onTabChange`를 추가해 탭이 바뀌면 부모가 메시지를 지움 (이전에 넣었던 2.5초 자동 사라짐은 제거)
