### PR TITLE
feat(hospital): 병원 선택 시 좌표도 함께 저장

### DIFF
--- a/src/api/hospitalProfile.ts
+++ b/src/api/hospitalProfile.ts
@@ -39,6 +39,8 @@ export interface HospitalProfile {
   tagline?: string | null;
   detail_blocks?: DetailBlock[] | null;
   doctors?: Doctor[] | null;
+  latitude?: number | null;
+  longitude?: number | null;
 }
 
 export interface HospitalProfileInput {
@@ -60,6 +62,8 @@ export interface HospitalProfileInput {
   tagline?: string | null;
   detail_blocks?: DetailBlock[] | null;
   doctors?: Doctor[] | null;
+  latitude?: number | null;
+  longitude?: number | null;
 }
 
 export interface HospitalReview {

--- a/src/api/partner.ts
+++ b/src/api/partner.ts
@@ -78,6 +78,8 @@ export interface PartnerProfile {
   tagline?: string | null;
   detail_blocks?: import("./hospitalProfile").DetailBlock[] | null;
   doctors?: import("./hospitalProfile").Doctor[] | null;
+  latitude?: number | null;
+  longitude?: number | null;
 }
 
 export interface PartnerProfileInput {
@@ -96,6 +98,8 @@ export interface PartnerProfileInput {
   tagline?: string | null;
   detail_blocks?: import("./hospitalProfile").DetailBlock[] | null;
   doctors?: import("./hospitalProfile").Doctor[] | null;
+  latitude?: number | null;
+  longitude?: number | null;
 }
 
 export function partnerSignup(data: {

--- a/src/components/PlacePicker.tsx
+++ b/src/components/PlacePicker.tsx
@@ -7,6 +7,10 @@ export interface PlaceResult {
   phone: string | null;
   address: string | null;
   roadAddress: string | null;
+  /** 앱의 치료탭이 거리 정렬·지도에 쓴다. 검색 응답에 이미 들어 있어
+   *  등록 시점에 같이 저장해 두면 나중에 채우러 다닐 일이 없다. */
+  latitude: number | null;
+  longitude: number | null;
 }
 
 /**

--- a/src/routes/admin_hospital_profiles.tsx
+++ b/src/routes/admin_hospital_profiles.tsx
@@ -65,6 +65,8 @@ const EMPTY: HospitalProfileInput = {
   treatment_items: [],
   opening_hours: null,
   doctors: [],
+  latitude: null,
+  longitude: null,
   tagline: "",
   detail_blocks: [],
   verified: false,
@@ -138,6 +140,8 @@ export default function AdminHospitalProfiles() {
       tagline: h.tagline ?? "",
       detail_blocks: h.detail_blocks ?? [],
       doctors: h.doctors ?? [],
+      latitude: h.latitude ?? null,
+      longitude: h.longitude ?? null,
       verified: h.verified ?? false,
       booking_url: h.booking_url ?? "",
     });
@@ -182,6 +186,10 @@ export default function AdminHospitalProfiles() {
                           name: pl.name,
                           phone: pl.phone ?? f.phone,
                           address: pl.roadAddress ?? pl.address ?? f.address,
+                          // 좌표는 사람이 볼 일이 없어 폼에 칸을 두지 않는다.
+                          // 앱이 거리 정렬·지도에 쓸 값이라 조용히 따라간다.
+                          latitude: pl.latitude,
+                          longitude: pl.longitude,
                         }))
                       }
                     />

--- a/src/routes/partner/PartnerProfile.tsx
+++ b/src/routes/partner/PartnerProfile.tsx
@@ -38,6 +38,8 @@ const EMPTY: PartnerProfileInput = {
   treatment_items: [],
   opening_hours: null,
   doctors: [],
+  latitude: null,
+  longitude: null,
   tagline: "",
   detail_blocks: [],
   booking_url: "",
@@ -75,6 +77,8 @@ export default function PartnerProfile() {
             tagline: p.tagline ?? "",
             detail_blocks: p.detail_blocks ?? [],
             doctors: p.doctors ?? [],
+            latitude: p.latitude ?? null,
+            longitude: p.longitude ?? null,
             booking_url: p.booking_url ?? "",
           });
         } else {
@@ -161,6 +165,10 @@ export default function PartnerProfile() {
                           // what the app already shows on the list card.
                           phone: pl.phone ?? s.phone,
                           address: pl.roadAddress ?? pl.address ?? s.address,
+                          // 좌표는 사람이 볼 일이 없어 폼에 칸을 두지 않는다.
+                          // 앱이 거리 정렬·지도에 쓸 값이라 조용히 따라간다.
+                          latitude: pl.latitude,
+                          longitude: pl.longitude,
                         }))
                       }
                     />


### PR DESCRIPTION
앱 치료탭이 카카오 검색을 거치지 않고 프로필을 직접 읽게 되면서, 거리 정렬과 지도에 쓸 좌표를 우리가 갖고 있어야 합니다. 장소 검색 응답에 이미 들어 있어 선택 시점에 조용히 따라갑니다 — 사람이 볼 값이 아니라 폼에 칸은 두지 않았습니다.

`EMPTY` / hydration / `onPick` 세 곳 모두에 넣었습니다. hydration을 빠뜨리면 다음 저장에서 좌표가 지워집니다(직전 PR의 `doctors`가 그랬습니다).

백엔드 PR #48 필요.