### PR TITLE
feat(admin): 미리 만든 프로필을 병원 계정으로 넘기는 기능

### DIFF
--- a/src/api/partnerAccount.ts
+++ b/src/api/partnerAccount.ts
@@ -28,3 +28,33 @@ export function setPartnerAccountStatus(
     { status },
   );
 }
+
+/** 주인이 없는 프로필 — 어드민이 온보딩용으로 미리 만들어 둔 것들. */
+export interface UnclaimedProfile {
+  id: string;
+  name: string;
+  address: string | null;
+  kakao_place_id: string;
+}
+
+export function listUnclaimedProfiles(): Promise<{ profiles: UnclaimedProfile[] }> {
+  return jsonFetchWithSession(API_ROOT + "/partner/unclaimed-profiles");
+}
+
+/**
+ * 미리 만들어 둔 프로필을 병원 계정에 넘긴다.
+ *
+ * 온보딩을 어드민이 시작하기 때문에 필요하다 — 넘겨주지 않으면 그 병원은
+ * 가입해도 자기 프로필을 수정할 수 없고, 공지 하나 올리려고 계속 우리에게
+ * 연락해야 한다.
+ */
+export function claimProfileForAccount(
+  accountId: string,
+  profileId: string,
+): Promise<{ id: string; owner_account_id: string }> {
+  return jsonFetchWithSession(
+    API_ROOT + "/partner/accounts/" + accountId + "/claim-profile",
+    { method: "POST" },
+    { profile_id: profileId },
+  );
+}

--- a/src/routes/admin_partner_accounts.tsx
+++ b/src/routes/admin_partner_accounts.tsx
@@ -4,7 +4,9 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { UserContext } from "../App";
 import { PrimaryButton, PrimaryNagativeButton } from "../components/button";
 import {
+  claimProfileForAccount,
   listPartnerAccounts,
+  listUnclaimedProfiles,
   setPartnerAccountStatus,
   type PartnerAccountStatus,
 } from "../api/partnerAccount";
@@ -16,6 +18,24 @@ export default function AdminPartnerAccounts() {
   const listQuery = useQuery({
     queryKey: ["admin", "partnerAccounts"],
     queryFn: listPartnerAccounts,
+  });
+
+  // 온보딩은 어드민이 프로필을 먼저 채우는 것으로 시작한다. 그 병원이 나중에
+  // 가입하면 미리 만들어 둔 프로필을 넘겨줘야 자기 손으로 관리할 수 있다.
+  const unclaimedQuery = useQuery({
+    queryKey: ["admin", "unclaimedProfiles"],
+    queryFn: listUnclaimedProfiles,
+  });
+
+  const claimMutation = useMutation({
+    mutationFn: ({ accountId, profileId }: { accountId: string; profileId: string }) =>
+      claimProfileForAccount(accountId, profileId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["admin", "partnerAccounts"] });
+      qc.invalidateQueries({ queryKey: ["admin", "unclaimedProfiles"] });
+      alert("프로필을 이 계정으로 넘겼습니다. 이제 병원이 직접 수정할 수 있습니다.");
+    },
+    onError: (e: any) => alert(e?.message ?? "이관 실패"),
   });
 
   const statusMutation = useMutation({
@@ -68,7 +88,32 @@ export default function AdminPartnerAccounts() {
                       <span style={{ color: "#9ca3af", fontSize: 12 }}>{a.claimedPlaceId}</span>
                     </>
                   ) : (
-                    <span style={{ color: "#9ca3af" }}>미작성</span>
+                    <div style={{ display: "grid", gap: 4 }}>
+                      <span style={{ color: "#9ca3af" }}>미작성</span>
+                      {(unclaimedQuery.data?.profiles.length ?? 0) > 0 && (
+                        <select
+                          defaultValue=""
+                          disabled={claimMutation.isPending}
+                          onChange={(e) => {
+                            const profileId = e.target.value;
+                            e.target.value = "";
+                            if (!profileId) return;
+                            if (!confirm("이 프로필을 해당 병원 계정으로 넘길까요? 이후 병원이 직접 수정하게 됩니다."))
+                              return;
+                            claimMutation.mutate({ accountId: a.id, profileId });
+                          }}
+                          style={select}
+                        >
+                          <option value="">기존 프로필 넘기기…</option>
+                          {unclaimedQuery.data?.profiles.map((pf) => (
+                            <option key={pf.id} value={pf.id}>
+                              {pf.name}
+                              {pf.address ? ` · ${pf.address}` : ""}
+                            </option>
+                          ))}
+                        </select>
+                      )}
+                    </div>
                   )}
                 </td>
                 <td style={td}>{a.contactName}</td>
@@ -101,6 +146,14 @@ export default function AdminPartnerAccounts() {
     </div>
   );
 }
+
+const select: CSSProperties = {
+  padding: "4px 6px",
+  border: "1px solid #ddd",
+  borderRadius: 6,
+  fontSize: 12,
+  maxWidth: 260,
+};
 
 const STATUS_LABEL: Record<PartnerAccountStatus, string> = {
   pending: "승인 대기",


### PR DESCRIPTION
파트너 승인 화면(`/admin/partner-accounts`)의 **프로필** 열에서, 주인 없는 프로필을 골라 그 계정으로 넘깁니다.

프로필이 "미작성"인 계정에만 나타납니다 — 이미 자기 프로필이 있으면 넘길 이유가 없습니다. 넘기기 전에 확인을 한 번 받습니다(이후 병원이 직접 수정하게 되므로).

## 배경
온보딩을 어드민이 먼저 채우는 방식으로 하면, 그 병원이 나중에 가입해도 `kakao_place_id` 유니크 제약 때문에 자기 프로필에 접근할 수 없습니다. 이관 없이는 병원이 공지 하나 올리려고 매번 관리자에게 연락해야 합니다.

백엔드 PR #50 필요.