### PR TITLE
fix(프로필 편집): 진료시간 드롭다운, 한글 오류 안내, placeholder 정리

### DIFF
--- a/src/api/partner.ts
+++ b/src/api/partner.ts
@@ -17,9 +17,12 @@ export function clearPartnerToken() {
 
 export class PartnerError extends Error {
   code: number;
-  constructor(code: number, message?: string) {
+  /** 400일 때 서버가 실어 보내는 필드별 사유. */
+  fields?: { path: string; message: string }[];
+  constructor(code: number, message?: string, fields?: { path: string; message: string }[]) {
     super(message);
     this.code = code;
+    this.fields = fields;
   }
 }
 
@@ -45,7 +48,7 @@ async function partnerFetch<T>(
   });
   if (!res.ok) {
     const b = await res.json().catch(() => ({}));
-    throw new PartnerError(res.status, b?.message);
+    throw new PartnerError(res.status, b?.message, b?.fields);
   }
   return res.status === 204 ? (undefined as T) : res.json();
 }

--- a/src/components/DoctorsEditor.tsx
+++ b/src/components/DoctorsEditor.tsx
@@ -97,13 +97,13 @@ export function DoctorsEditor({
                     <input
                       value={d.name}
                       onChange={(e) => set(i, { ...d, name: e.target.value })}
-                      placeholder="이름 (예: 김웅수)"
+                      placeholder="이름"
                       style={{ ...inp, flex: 1 }}
                     />
                     <input
                       value={d.title ?? ""}
                       onChange={(e) => set(i, { ...d, title: e.target.value })}
-                      placeholder="직함 (예: 대표원장 · 소아안과 전문의)"
+                      placeholder="직함"
                       style={{ ...inp, flex: 1.4 }}
                     />
                   </div>

--- a/src/components/PartnerNoticesEditor.tsx
+++ b/src/components/PartnerNoticesEditor.tsx
@@ -62,8 +62,13 @@ export function PartnerNoticesEditor({ api }: { api: ProfileEditorApi }) {
   return (
     <div>
       <p style={hint}>
-        재개원 안내, 원장 변경, 이벤트처럼 앱 병원 상세에 노출할 소식입니다. 고정한 소식이 항상 위에
-        표시됩니다.
+        재개원 안내, 원장 변경, 이벤트처럼 앱 병원 상세에 노출할 소식입니다. 소식은 등록·수정하는
+        즉시 반영됩니다(아래 저장 버튼과 별개).
+      </p>
+      <p style={hint}>
+        📌 <b>고정</b>한 소식 하나만 앱 병원 상세의 첫 화면에 뜹니다. 고정한 것이 없으면 첫 화면에는
+        아무 소식도 안 보이고 소식 탭에서만 볼 수 있습니다. 새로 고정하면 이전 고정은 자동으로
+        해제됩니다.
       </p>
 
       <div style={{ display: "grid", gap: 6, marginBottom: 14 }}>
@@ -88,7 +93,7 @@ export function PartnerNoticesEditor({ api }: { api: ProfileEditorApi }) {
               checked={draft.pinned}
               onChange={(e) => setDraft((d) => ({ ...d, pinned: e.target.checked }))}
             />
-            고정
+            📌 고정
           </label>
         </div>
         <textarea

--- a/src/components/PlacePicker.tsx
+++ b/src/components/PlacePicker.tsx
@@ -70,7 +70,7 @@ export function PlacePicker({
               void run();
             }
           }}
-          placeholder="병원 이름으로 검색 (예: 누네안과병원 서울)"
+          placeholder="병원 이름으로 검색"
           style={{ ...inp, flex: 1 }}
         />
         <button type="button" onClick={() => void run()} disabled={busy} style={btn}>

--- a/src/components/hospitalCardEditors.tsx
+++ b/src/components/hospitalCardEditors.tsx
@@ -215,6 +215,56 @@ export type OpeningHours = Partial<Record<(typeof DAYS)[number]["key"], DayHours
   note?: string;
 };
 
+/** 00:00~23:30을 30분 간격으로. 병원 시간은 30분 단위를 벗어나는 일이 드물다. */
+const TIME_SLOTS: { value: string; label: string }[] = (() => {
+  const out: { value: string; label: string }[] = [];
+  for (let m = 0; m < 24 * 60; m += 30) {
+    const h = Math.floor(m / 60);
+    const mm = m % 60;
+    const value = `${String(h).padStart(2, "0")}:${String(mm).padStart(2, "0")}`;
+    const ampm = h < 12 ? "오전" : "오후";
+    const h12 = h % 12 === 0 ? 12 : h % 12;
+    out.push({ value, label: `${ampm} ${h12}:${String(mm).padStart(2, "0")}` });
+  }
+  return out;
+})();
+
+/**
+ * 시간 드롭다운.
+ *
+ * `<input type="time">`은 브라우저마다 생김새가 다르고 키보드로 시·분을 따로
+ * 쳐야 해서, 일곱 요일 × 네 칸을 채우는 데 손이 많이 간다. 고를 값이 48개뿐이라
+ * 목록에서 집는 편이 빠르다.
+ */
+function TimeSelect({
+  value,
+  onChange,
+  placeholder,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  placeholder?: string;
+}) {
+  return (
+    <select value={value} onChange={(e) => onChange(e.target.value)} style={timeSelect}>
+      {placeholder != null && <option value="">{placeholder}</option>}
+      {TIME_SLOTS.map((t) => (
+        <option key={t.value} value={t.value}>
+          {t.label}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+const timeSelect: CSSProperties = {
+  padding: "6px 8px",
+  border: "1px solid #ddd",
+  borderRadius: 6,
+  fontSize: 13,
+  minWidth: 104,
+};
+
 /**
  * Weekly hours grid. No map API supplies these, so the clinic enters them.
  *
@@ -246,6 +296,20 @@ export function OpeningHoursEditor({
         체크를 해제하면 그 요일은 휴진으로 표시됩니다. 아무것도 입력하지 않으면 앱에서 진료시간
         섹션 자체가 표시되지 않습니다.
       </p>
+      {hours.mon != null && (
+        <button
+          type="button"
+          onClick={() => {
+            // 월요일을 화~금에 복사. 대부분의 병원이 평일 시간이 같아서,
+            // 같은 값을 네 번 더 고르는 일이 제일 지겹다.
+            const mon = hours.mon!;
+            onChange({ ...hours, tue: { ...mon }, wed: { ...mon }, thu: { ...mon }, fri: { ...mon } });
+          }}
+          style={{ ...smallBtn, marginBottom: 8 }}
+        >
+          월요일과 같게 (화~금)
+        </button>
+      )}
       <div style={{ display: "grid", gap: 6 }}>
         {DAYS.map(({ key, label }) => {
           const d = hours[key];
@@ -264,32 +328,20 @@ export function OpeningHoursEditor({
               </label>
               {open ? (
                 <>
-                  <input
-                    type="time"
-                    value={d.open}
-                    onChange={(e) => setDay(key, { ...d, open: e.target.value })}
-                    style={{ ...inp, width: 110 }}
-                  />
+                  <TimeSelect value={d.open} onChange={(v) => setDay(key, { ...d, open: v })} />
                   <span>~</span>
-                  <input
-                    type="time"
-                    value={d.close}
-                    onChange={(e) => setDay(key, { ...d, close: e.target.value })}
-                    style={{ ...inp, width: 110 }}
-                  />
-                  <span style={{ color: "#6b7280", fontSize: 12 }}>점심</span>
-                  <input
-                    type="time"
+                  <TimeSelect value={d.close} onChange={(v) => setDay(key, { ...d, close: v })} />
+                  <span style={{ color: "#6b7280", fontSize: 12, marginLeft: 6 }}>점심</span>
+                  <TimeSelect
                     value={d.lunchStart ?? ""}
-                    onChange={(e) => setDay(key, { ...d, lunchStart: e.target.value || null })}
-                    style={{ ...inp, width: 110 }}
+                    placeholder="없음"
+                    onChange={(v) => setDay(key, { ...d, lunchStart: v || null })}
                   />
                   <span>~</span>
-                  <input
-                    type="time"
+                  <TimeSelect
                     value={d.lunchEnd ?? ""}
-                    onChange={(e) => setDay(key, { ...d, lunchEnd: e.target.value || null })}
-                    style={{ ...inp, width: 110 }}
+                    placeholder="없음"
+                    onChange={(v) => setDay(key, { ...d, lunchEnd: v || null })}
                   />
                 </>
               ) : (

--- a/src/constants/profileFields.ts
+++ b/src/constants/profileFields.ts
@@ -1,0 +1,58 @@
+/**
+ * 저장에 실패했을 때 "어느 탭 어느 칸이 문제인지"를 한국어로 짚어주기 위한 표.
+ *
+ * 서버는 `banner_image_url: Invalid url` 같은 필드 경로를 돌려준다. 병원 담당자
+ * 입장에서 그건 아무 정보도 아니고, 탭이 일곱 개라 어디를 열어야 할지도 모른다.
+ * 경로를 탭 이름과 칸 이름으로 옮겨 적는다.
+ */
+export const FIELD_LABELS: Record<string, { tab: string; label: string }> = {
+  kakao_place_id: { tab: "기본 정보", label: "병원 찾기" },
+  name: { tab: "기본 정보", label: "병원명" },
+  tagline: { tab: "기본 정보", label: "한 줄 소개" },
+  keywords: { tab: "기본 정보", label: "키워드 태그" },
+  phone: { tab: "기본 정보", label: "전화" },
+  address: { tab: "기본 정보", label: "주소" },
+  booking_url: { tab: "기본 정보", label: "예약 링크" },
+  images: { tab: "배너 사진", label: "배너 사진" },
+  banner_image_url: { tab: "배너 사진", label: "배너 이미지" },
+  thumbnail_url: { tab: "배너 사진", label: "대표 사진" },
+  detail_blocks: { tab: "상세 설명", label: "상세 설명" },
+  doctors: { tab: "의사 정보", label: "의사 정보" },
+  opening_hours: { tab: "진료시간", label: "진료시간" },
+  treatment_items: { tab: "치료항목", label: "치료항목" },
+  description: { tab: "상세 설명", label: "소개 글" },
+  latitude: { tab: "기본 정보", label: "위치 좌표" },
+  longitude: { tab: "기본 정보", label: "위치 좌표" },
+};
+
+/** zod 메시지를 병원 담당자가 읽을 수 있는 말로. */
+function humanReason(message: string): string {
+  if (/url/i.test(message)) return "주소 형식이 올바르지 않습니다 (http로 시작해야 합니다)";
+  if (/required|expected/i.test(message)) return "값이 비어 있습니다";
+  if (/at most|too big|max/i.test(message)) return "너무 깁니다";
+  if (/at least|too small|min/i.test(message)) return "값이 비어 있습니다";
+  return message;
+}
+
+/**
+ * 서버가 돌려준 필드 오류를 "탭 · 항목 — 이유" 줄로 바꾼다.
+ * 배열 필드는 인덱스를 사람이 세는 번호(1부터)로 바꿔 붙인다.
+ */
+export function describeFieldErrors(
+  fields: { path: string; message: string }[] | undefined,
+): string[] {
+  if (!fields || fields.length === 0) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const f of fields) {
+    const [root, index] = f.path.split(".");
+    const meta = FIELD_LABELS[root];
+    if (!meta) continue;
+    const nth = index != null && /^\d+$/.test(index) ? ` ${Number(index) + 1}번째` : "";
+    const line = `[${meta.tab}] ${meta.label}${nth} — ${humanReason(f.message)}`;
+    if (seen.has(line)) continue;
+    seen.add(line);
+    out.push(line);
+  }
+  return out;
+}

--- a/src/lib/fetch.tsx
+++ b/src/lib/fetch.tsx
@@ -1,9 +1,13 @@
 export class HttpError extends Error {
   code: number;
-  constructor(code: number, message?: string) {
+  /** 400일 때 서버가 실어 보내는 필드별 사유. 화면이 어느 탭·어느 칸이
+   *  문제인지 짚어주는 데 쓴다. */
+  fields?: { path: string; message: string }[];
+  constructor(code: number, message?: string, fields?: { path: string; message: string }[]) {
     super(message);
     this.name = "HttpError";
     this.code = code;
+    this.fields = fields;
   }
 }
 
@@ -38,7 +42,7 @@ export async function jsonFetch<T = any>(
     if (!result.ok) {
       if (result.body) {
         const body = await result.json().catch(() => ({}));
-        reject(new HttpError(result.status, body?.message));
+        reject(new HttpError(result.status, body?.message, body?.fields));
       } else {
         reject(new HttpError(result.status));
       }
@@ -100,7 +104,7 @@ export async function jsonFetchWithSession<T = any>(
     if (!result.ok) {
       if (result.body) {
         const body = await result.json().catch(() => ({}));
-        reject(new HttpError(result.status, body?.message));
+        reject(new HttpError(result.status, body?.message, body?.fields));
       } else {
         reject(new HttpError(result.status));
       }

--- a/src/routes/admin_hospital_profiles.tsx
+++ b/src/routes/admin_hospital_profiles.tsx
@@ -26,6 +26,7 @@ import { FormTabs } from "../components/FormTabs";
 import { PlacePicker } from "../components/PlacePicker";
 import { HospitalNoticesEditor } from "../components/HospitalNoticesEditor";
 import { DoctorsEditor, cleanDoctors } from "../components/DoctorsEditor";
+import { describeFieldErrors } from "../constants/profileFields";
 
 interface HospitalListItem {
   id: string;
@@ -105,7 +106,14 @@ export default function AdminHospitalProfiles() {
       qc.invalidateQueries({ queryKey: ["admin", "hospitalProfiles"] });
       reset();
     },
-    onError: (e: any) => alert(e?.message ?? "저장 실패"),
+    onError: (e: any) => {
+      const details = describeFieldErrors(e?.fields);
+      alert(
+        details.length > 0
+          ? `저장하지 못했습니다.\n\n${details.join("\n")}`
+          : (e?.message ?? "저장하지 못했습니다."),
+      );
+    },
   });
 
   const delMutation = useMutation({

--- a/src/routes/partner/PartnerProfile.tsx
+++ b/src/routes/partner/PartnerProfile.tsx
@@ -10,6 +10,7 @@ import {
 } from "../../api/partner";
 import { normaliseProfileUrls } from "../../api/hospitalProfile";
 import { hospitalApi, partnerApi } from "../../api/profileEditorApi";
+import { describeFieldErrors } from "../../constants/profileFields";
 import { UserContext } from "../../App";
 import {
   KeywordsEditor,
@@ -61,6 +62,8 @@ export default function PartnerProfile() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [msg, setMsg] = useState<string | null>(null);
+  // 어느 탭 어느 칸이 문제인지. 문장 하나로는 탭이 일곱 개라 찾을 수가 없다.
+  const [fieldErrors, setFieldErrors] = useState<string[]>([]);
 
   useEffect(() => {
     if (!hasPartnerToken && !isHospitalAdmin) {
@@ -116,6 +119,7 @@ export default function PartnerProfile() {
 
   const save = async () => {
     setMsg(null);
+    setFieldErrors([]);
     setSaving(true);
     try {
       await api.saveProfile(
@@ -125,7 +129,13 @@ export default function PartnerProfile() {
       );
       setMsg("저장되었습니다.");
     } catch (e: any) {
-      setMsg(e?.message ?? "저장 실패");
+      const details = describeFieldErrors(e?.fields);
+      setFieldErrors(details);
+      setMsg(
+        details.length > 0
+          ? "저장하지 못했습니다. 아래 항목을 확인해 주세요."
+          : (e?.message ?? "저장하지 못했습니다."),
+      );
     } finally {
       setSaving(false);
     }
@@ -172,7 +182,10 @@ export default function PartnerProfile() {
         <FormTabs
           // The save banner sits outside the tabs, so leaving it up made
           // "저장되었습니다" follow the user into a tab they hadn't saved.
-          onTabChange={() => setMsg(null)}
+          onTabChange={() => {
+            setMsg(null);
+            setFieldErrors([]);
+          }}
           tabs={[
             {
               key: "basic",
@@ -302,7 +315,22 @@ export default function PartnerProfile() {
           ]}
         />
 
-        {msg && <p style={{ fontSize: 13, color: msg.includes("저장되") ? "#0d7d6f" : "#b3261e" }}>{msg}</p>}
+        {msg && (
+        <p style={{ fontSize: 13, color: msg.includes("저장되") ? "#0d7d6f" : "#b3261e" }}>{msg}</p>
+      )}
+      {fieldErrors.length > 0 && (
+        <ul style={{ margin: "4px 0 0", paddingLeft: 18, color: "#b3261e", fontSize: 13 }}>
+          {fieldErrors.map((line) => (
+            <li key={line}>{line}</li>
+          ))}
+        </ul>
+      )}
+      {/* 탭이 일곱 개라 탭마다 저장 버튼이 있는 줄 알기 쉽다. 실제로는 모든
+          탭이 한 폼이고 저장은 한 번이다. */}
+      <p style={{ color: "#6b7280", fontSize: 12, margin: "10px 0 0" }}>
+        모든 탭의 내용이 저장 버튼 한 번으로 함께 저장됩니다. 소식은 등록·수정할 때 바로
+        반영됩니다.
+      </p>
         <button style={{ ...saveBtn, opacity: canSave && !saving ? 1 : 0.5 }} disabled={!canSave || saving} onClick={save}>
           {saving ? "저장 중…" : "저장"}
         </button>


### PR DESCRIPTION
## 진료시간 입력
`<input type="time">`은 브라우저마다 생김새가 다르고 시·분을 따로 쳐야 해서, **일곱 요일 × 네 칸**을 채우는 게 고역이었습니다.

- 30분 간격 드롭다운(`오전 9:00` 표기)으로 교체 — 고를 값이 48개뿐이라 목록에서 집는 편이 빠릅니다
- **월요일과 같게 (화~금)** 버튼 추가 — 평일 시간이 같은 병원이 대부분인데 같은 값을 네 번 더 고르는 게 제일 지겹습니다

## 저장 실패 안내
`banner_image_url: Invalid url` 대신:

> [기본 정보] 예약 링크 — 주소 형식이 올바르지 않습니다 (http로 시작해야 합니다)

탭이 일곱 개라 문장 하나로는 어디를 열어야 할지 알 수 없었습니다. 배열 항목은 `의사 정보 2번째`처럼 번호를 붙입니다.

## 그 외
- **저장 범위 안내** — 탭마다 저장 버튼이 있는 줄 알기 쉬워서, 모든 탭이 한 번에 저장된다는 것과 소식은 예외라는 것을 명시
- 고정 공지 안내 문구 (하나만, 없으면 첫 화면에 안 보임)
- placeholder에서 실명 제거 (`김웅수` → `이름`, `누네안과병원 서울` → 일반 문구)

백엔드 PR #52 필요.
