### PR TITLE
feat(파트너): 진료 치료 선택 · 이벤트 탭 · 미리보기

### DIFF
--- a/src/api/hospitalProfile.ts
+++ b/src/api/hospitalProfile.ts
@@ -30,6 +30,7 @@ export interface HospitalProfile {
   hospital_id: string | null;
   thumbnail_url: string | null;
   keywords: string[];
+  treatment_categories: string[];
   treatment_items: TreatmentItem[] | null;
   verified: boolean;
   booking_url: string | null;
@@ -55,6 +56,7 @@ export interface HospitalProfileInput {
   hospital_id?: string | null;
   thumbnail_url?: string | null;
   keywords?: string[];
+  treatment_categories?: string[];
   treatment_items?: TreatmentItem[];
   verified?: boolean;
   booking_url?: string | null;

--- a/src/api/partner.ts
+++ b/src/api/partner.ts
@@ -74,6 +74,7 @@ export interface PartnerProfile {
   address: string | null;
   thumbnail_url: string | null;
   keywords: string[];
+  treatment_categories: string[];
   treatment_items: TreatmentItem[] | null;
   booking_url: string | null;
   status: string;
@@ -95,6 +96,7 @@ export interface PartnerProfileInput {
   address?: string;
   thumbnail_url?: string | null;
   keywords?: string[];
+  treatment_categories?: string[];
   treatment_items?: TreatmentItem[];
   booking_url?: string | null;
   opening_hours?: unknown | null;

--- a/src/components/ProfilePreview.tsx
+++ b/src/components/ProfilePreview.tsx
@@ -1,0 +1,330 @@
+import { useEffect, type CSSProperties, type ReactNode } from "react";
+
+import { categoryLabel, type TreatmentItem } from "../constants/treatmentCategories";
+
+/**
+ * 지금 화면에 입력한 내용이 앱에서 어떻게 보이는지.
+ *
+ * 마이오닥 웹 상세 페이지를 새 탭으로 여는 방법도 있지만 두 가지가 걸린다.
+ * 저장한 내용만 보이므로 고치는 중에는 쓸 수 없고, 승인 전(pending) 프로필은
+ * 앱이 404 로 막아 아예 열리지 않는다. 파트너가 미리보기를 누르는 시점이
+ * 정확히 그 두 경우다.
+ *
+ * 그래서 폼 상태를 그대로 그린다. 저장하지 않아도, 승인 전이어도 보인다.
+ * 앱의 실제 픽셀을 재현하는 것이 목적이 아니라 "무엇이 어디에 들어가는지"를
+ * 보여주는 것이 목적이라, 배치와 순서만 맞춘다.
+ */
+export interface PreviewData {
+  name: string;
+  tagline?: string | null;
+  address?: string;
+  phone?: string;
+  thumbnail_url?: string | null;
+  images?: string[];
+  keywords?: string[];
+  treatment_categories?: string[];
+  treatment_items?: TreatmentItem[];
+  doctors?: { name: string; title?: string | null }[] | null;
+}
+
+export function ProfilePreview({
+  data,
+  onClose,
+}: {
+  data: PreviewData;
+  onClose: () => void;
+}) {
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", onKey);
+    // 뒤 화면이 같이 스크롤되면 어느 쪽을 보고 있는지 헷갈린다.
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prev;
+    };
+  }, [onClose]);
+
+  const cats = data.treatment_categories ?? [];
+  const items = (data.treatment_items ?? []).filter((it) => it.name?.trim());
+  const banner = data.images?.[0] ?? data.thumbnail_url ?? null;
+
+  return (
+    <div style={backdrop} onClick={onClose} role="presentation">
+      <div
+        style={sheet}
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label="앱 미리보기"
+      >
+        <div style={sheetHead}>
+          <strong style={{ fontSize: 15 }}>앱 미리보기</strong>
+          <button type="button" onClick={onClose} style={closeBtn} aria-label="닫기">
+            ✕
+          </button>
+        </div>
+
+        <p style={hint}>
+          저장 전 내용입니다. 실제 앱에는 저장 후 반영됩니다.
+        </p>
+
+        <div style={scrollArea}>
+          {/* ── 치료탭 목록 카드 ───────────────────────────── */}
+          <Label>치료탭 목록에서</Label>
+          <div style={phone}>
+            <div style={card}>
+              <div style={{ display: "flex", gap: 10 }}>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={badgeRow}>
+                    <Badge tone="grey">의원</Badge>
+                    {cats.length > 0 && <Badge tone="blue">{categoryLabel(cats[0])}</Badge>}
+                  </div>
+                  <div style={cardName}>{data.name || "병원명"}</div>
+                  {data.tagline ? <div style={cardSub}>{data.tagline}</div> : null}
+                  {data.address ? <div style={cardSub}>{data.address}</div> : null}
+                </div>
+                {data.thumbnail_url ? (
+                  <img src={data.thumbnail_url} alt="" style={thumb} />
+                ) : null}
+              </div>
+
+              {(data.keywords ?? []).length > 0 && (
+                <div style={{ display: "flex", gap: 6, flexWrap: "wrap", marginTop: 8 }}>
+                  {(data.keywords ?? []).slice(0, 4).map((k) => (
+                    <span key={k} style={keywordChip}>
+                      {k}
+                    </span>
+                  ))}
+                </div>
+              )}
+
+              {items.length > 0 && (
+                <div style={itemBox}>
+                  <div style={{ fontWeight: 700, fontSize: 13 }}>{items[0].name}</div>
+                  <PriceLine item={items[0]} />
+                </div>
+              )}
+            </div>
+          </div>
+
+          {cats.length === 0 && (
+            <p style={warnLine}>
+              진료하는 치료를 고르지 않아, 부모가 치료를 선택해 검색하면 이 카드가
+              나오지 않습니다.
+            </p>
+          )}
+
+          {/* ── 병원 상세 ─────────────────────────────────── */}
+          <Label>병원 상세에서</Label>
+          <div style={phone}>
+            {banner ? (
+              <img src={banner} alt="" style={bannerImg} />
+            ) : (
+              <div style={{ ...bannerImg, ...bannerEmpty }}>배너 사진 없음</div>
+            )}
+            <div style={{ padding: "14px 14px 18px" }}>
+              <div style={{ fontSize: 18, fontWeight: 800 }}>{data.name || "병원명"}</div>
+              {data.tagline ? (
+                <div style={{ ...cardSub, marginTop: 4 }}>{data.tagline}</div>
+              ) : null}
+              {data.phone || data.address ? (
+                <div style={{ ...cardSub, marginTop: 8 }}>
+                  {[data.address, data.phone].filter(Boolean).join(" · ")}
+                </div>
+              ) : null}
+
+              {cats.length > 0 && (
+                <>
+                  <SectionTitle>진료하는 치료</SectionTitle>
+                  <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+                    {cats.map((k) => (
+                      <Badge key={k} tone="blue">
+                        {categoryLabel(k)}
+                      </Badge>
+                    ))}
+                  </div>
+                </>
+              )}
+
+              {items.length > 0 && (
+                <>
+                  <SectionTitle>이벤트</SectionTitle>
+                  {items.map((it, i) => (
+                    <div key={i} style={itemBox}>
+                      <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+                        {it.category ? (
+                          <Badge tone="grey">{categoryLabel(it.category)}</Badge>
+                        ) : null}
+                        <span style={{ fontWeight: 700, fontSize: 13 }}>{it.name}</span>
+                      </div>
+                      <PriceLine item={it} />
+                      {it.description ? (
+                        <div style={{ ...cardSub, marginTop: 4 }}>{it.description}</div>
+                      ) : null}
+                    </div>
+                  ))}
+                </>
+              )}
+
+              {(data.doctors ?? []).length > 0 && (
+                <>
+                  <SectionTitle>의료진</SectionTitle>
+                  {(data.doctors ?? []).map((d, i) => (
+                    <div key={i} style={{ fontSize: 13, marginBottom: 4 }}>
+                      <b>{d.name}</b>
+                      {d.title ? <span style={{ color: "#6b7280" }}> · {d.title}</span> : null}
+                    </div>
+                  ))}
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PriceLine({ item }: { item: TreatmentItem }) {
+  if (item.normalPrice == null && item.eventPrice == null) return null;
+  const won = (n: number) => n.toLocaleString("ko-KR") + "원";
+  return (
+    <div style={{ fontSize: 13, marginTop: 3 }}>
+      {item.eventPrice != null && item.normalPrice != null ? (
+        <>
+          <s style={{ color: "#9ca3af" }}>{won(item.normalPrice)}</s>{" "}
+          <b style={{ color: "#b3261e" }}>{won(item.eventPrice)}</b>
+        </>
+      ) : (
+        <b>{won((item.eventPrice ?? item.normalPrice)!)}</b>
+      )}
+    </div>
+  );
+}
+
+function Label({ children }: { children: ReactNode }) {
+  return <div style={sectionLabel}>{children}</div>;
+}
+function SectionTitle({ children }: { children: ReactNode }) {
+  return <div style={{ fontSize: 13, fontWeight: 700, margin: "16px 0 6px" }}>{children}</div>;
+}
+function Badge({ children, tone }: { children: ReactNode; tone: "blue" | "grey" }) {
+  return (
+    <span style={tone === "blue" ? badgeBlue : badgeGrey}>{children}</span>
+  );
+}
+
+/* ---- styles ------------------------------------------------------------ */
+
+const backdrop: CSSProperties = {
+  position: "fixed",
+  inset: 0,
+  background: "rgba(15,23,42,.45)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: 16,
+  zIndex: 100,
+};
+const sheet: CSSProperties = {
+  background: "#fff",
+  borderRadius: 14,
+  width: "min(440px, 100%)",
+  maxHeight: "min(88vh, 900px)",
+  display: "flex",
+  flexDirection: "column",
+  overflow: "hidden",
+};
+const sheetHead: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  padding: "14px 16px 10px",
+  borderBottom: "1px solid #eef1f5",
+};
+const closeBtn: CSSProperties = {
+  border: "none",
+  background: "transparent",
+  fontSize: 16,
+  cursor: "pointer",
+  color: "#6b7280",
+  padding: 4,
+  lineHeight: 1,
+};
+const hint: CSSProperties = {
+  margin: 0,
+  padding: "8px 16px",
+  fontSize: 12,
+  color: "#6b7280",
+  background: "#f8fafc",
+};
+const scrollArea: CSSProperties = { overflowY: "auto", padding: "14px 16px 20px" };
+const sectionLabel: CSSProperties = {
+  fontSize: 11,
+  fontWeight: 700,
+  letterSpacing: ".06em",
+  color: "#9ca3af",
+  margin: "10px 0 8px",
+};
+const phone: CSSProperties = {
+  border: "1px solid #e5e7eb",
+  borderRadius: 12,
+  overflow: "hidden",
+  background: "#f6f8fb",
+};
+const card: CSSProperties = { background: "#fff", padding: 12, margin: 10, borderRadius: 10 };
+const cardName: CSSProperties = { fontSize: 15, fontWeight: 800, marginTop: 5 };
+const cardSub: CSSProperties = { fontSize: 13, color: "#6b7280", marginTop: 3 };
+const badgeRow: CSSProperties = { display: "flex", gap: 5, flexWrap: "wrap" };
+const badgeBlue: CSSProperties = {
+  fontSize: 11,
+  fontWeight: 700,
+  padding: "2px 8px",
+  borderRadius: 999,
+  background: "#e8f0fb",
+  color: "#1a5fc4",
+};
+const badgeGrey: CSSProperties = { ...badgeBlue, background: "#f1f3f5", color: "#5a6673" };
+const keywordChip: CSSProperties = {
+  fontSize: 11.5,
+  color: "#6b7280",
+  background: "#f6f8fb",
+  padding: "3px 8px",
+  borderRadius: 6,
+};
+const thumb: CSSProperties = {
+  width: 62,
+  height: 62,
+  borderRadius: 8,
+  objectFit: "cover",
+  flexShrink: 0,
+};
+const itemBox: CSSProperties = {
+  background: "#f6f8fb",
+  borderRadius: 8,
+  padding: "9px 11px",
+  marginTop: 8,
+};
+const bannerImg: CSSProperties = {
+  width: "100%",
+  height: 150,
+  objectFit: "cover",
+  display: "block",
+};
+const bannerEmpty: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  background: "#e9edf2",
+  color: "#9ca3af",
+  fontSize: 13,
+};
+const warnLine: CSSProperties = {
+  fontSize: 12.5,
+  color: "#b3261e",
+  margin: "8px 2px 0",
+};

--- a/src/components/hospitalCardEditors.tsx
+++ b/src/components/hospitalCardEditors.tsx
@@ -1,7 +1,8 @@
-import { useState, type CSSProperties } from "react";
+import { useEffect, useRef, useState, type CSSProperties } from "react";
 
 import {
   TREATMENT_CATEGORIES,
+  categoryLabel,
   type TreatmentItem,
 } from "../constants/treatmentCategories";
 
@@ -81,7 +82,9 @@ export function TreatmentItemsEditor({
     onChange(value.map((it, idx) => (idx === i ? { ...it, ...patch } : it)));
   }
   function addItem() {
-    onChange([...value, { category: "dreamLens", name: "" }]);
+    // 카테고리는 비워서 시작한다. 이벤트는 특정 치료에 묶이지 않는 것도 있고
+    // (예: 첫 방문 검진 할인), 기본값을 넣어두면 잘못 묶인 채로 저장된다.
+    onChange([...value, { category: "", name: "" }]);
   }
   function num(v: string): number | null {
     const n = Number(v.replace(/[^0-9]/g, ""));
@@ -94,10 +97,12 @@ export function TreatmentItemsEditor({
         <div key={i} style={itemCard}>
           <div style={{ display: "flex", gap: 8, marginBottom: 8 }}>
             <select
-              value={it.category}
+              value={it.category ?? ""}
               onChange={(e) => update(i, { category: e.target.value })}
               style={{ ...inp, flex: "0 0 160px" }}
+              title="어떤 치료의 이벤트인지 (선택)"
             >
+              <option value="">치료 무관</option>
               {TREATMENT_CATEGORIES.map((c) => (
                 <option key={c.key} value={c.key}>
                   {c.label}
@@ -107,7 +112,7 @@ export function TreatmentItemsEditor({
             <input
               value={it.name}
               onChange={(e) => update(i, { name: e.target.value })}
-              placeholder="항목명 (예: 드림렌즈 피팅)"
+              placeholder="이벤트명 (예: 드림렌즈 피팅 첫 방문 할인)"
               style={{ ...inp, flex: 1 }}
             />
             <button
@@ -143,7 +148,7 @@ export function TreatmentItemsEditor({
         </div>
       ))}
       <button type="button" onClick={addItem} style={smallBtn}>
-        + 치료항목 추가
+        + 이벤트 추가
       </button>
     </div>
   );
@@ -428,6 +433,116 @@ export function OpeningHoursEditor({
         placeholder="추가 안내 (예: 공휴일 휴진, 예약제 운영)"
         style={{ ...inp, width: "100%", marginTop: 10 }}
       />
+    </div>
+  );
+}
+
+/**
+ * 이 병원이 하는 치료를 고르는 드롭다운.
+ *
+ * 치료탭 검색이 이 값을 본다. 예전에는 이벤트 항목에 붙은 category 로
+ * 판단했는데, 그러면 가격표를 올리지 않은 병원은 그 치료를 해도 검색되지
+ * 않았다. 고르기만 하면 검색에 잡히도록 분리한다.
+ *
+ * `select multiple`을 쓰지 않은 이유: 여러 개를 고르려면 ctrl+클릭을 알아야
+ * 하고, 하나를 잘못 누르면 나머지 선택이 통째로 날아간다. 열어서 체크하는
+ * 방식은 그런 실수가 없다.
+ */
+export function TreatmentCategoryPicker({
+  value,
+  onChange,
+}: {
+  value: string[];
+  onChange: (next: string[]) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const boxRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onDocDown(e: MouseEvent) {
+      if (!boxRef.current?.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener("mousedown", onDocDown);
+    return () => document.removeEventListener("mousedown", onDocDown);
+  }, [open]);
+
+  function toggle(key: string) {
+    onChange(value.includes(key) ? value.filter((k) => k !== key) : [...value, key]);
+  }
+
+  const summary =
+    value.length === 0
+      ? "선택 안 함"
+      : value.map((k) => categoryLabel(k)).join(", ");
+
+  return (
+    <div ref={boxRef} style={{ position: "relative" }}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        style={{
+          ...inp,
+          textAlign: "left",
+          cursor: "pointer",
+          background: "#fff",
+          color: value.length === 0 ? "#9ca3af" : "inherit",
+          display: "flex",
+          justifyContent: "space-between",
+          gap: 8,
+        }}
+      >
+        <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+          {summary}
+        </span>
+        <span aria-hidden style={{ color: "#6b7280" }}>{open ? "▲" : "▼"}</span>
+      </button>
+
+      {open && (
+        <div
+          style={{
+            position: "absolute",
+            zIndex: 20,
+            top: "calc(100% + 4px)",
+            left: 0,
+            right: 0,
+            background: "#fff",
+            border: "1px solid #ccc",
+            borderRadius: 6,
+            boxShadow: "0 6px 18px rgba(0,0,0,.12)",
+            padding: 4,
+          }}
+        >
+          {TREATMENT_CATEGORIES.map((c) => (
+            <label
+              key={c.key}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                padding: "8px 10px",
+                cursor: "pointer",
+                borderRadius: 4,
+                fontSize: 14,
+              }}
+            >
+              <input
+                type="checkbox"
+                checked={value.includes(c.key)}
+                onChange={() => toggle(c.key)}
+              />
+              {c.label}
+            </label>
+          ))}
+        </div>
+      )}
+
+      {value.length === 0 && (
+        <p style={{ margin: "6px 0 0", fontSize: 12, color: "#b3261e" }}>
+          하나도 고르지 않으면 부모가 치료를 선택해 검색할 때 이 병원이 나오지 않습니다.
+        </p>
+      )}
     </div>
   );
 }

--- a/src/constants/treatmentCategories.ts
+++ b/src/constants/treatmentCategories.ts
@@ -21,8 +21,11 @@ export function categoryLabel(key: string): string {
   return TREATMENT_CATEGORIES.find((c) => c.key === key)?.label ?? key;
 }
 
+/** 이벤트·프로모션 한 줄.
+ *  category 는 상세에서 묶어 보여줄 때만 쓴다. 병원이 어떤 치료를 하는지는
+ *  프로필의 treatment_categories 가 답하므로 여기서는 비워도 된다. */
 export interface TreatmentItem {
-  category: string;
+  category?: string;
   name: string;
   normalPrice?: number | null;
   eventPrice?: number | null;

--- a/src/routes/admin_hospital_profiles.tsx
+++ b/src/routes/admin_hospital_profiles.tsx
@@ -18,6 +18,7 @@ import {
 import { getHospitalList } from "../api/hospital";
 import {
   KeywordsEditor,
+  TreatmentCategoryPicker,
   OpeningHoursEditor,
   TreatmentItemsEditor,
 } from "../components/hospitalCardEditors";
@@ -63,6 +64,7 @@ const EMPTY: HospitalProfileInput = {
   hospital_id: null,
   thumbnail_url: "",
   keywords: [],
+  treatment_categories: [],
   treatment_items: [],
   opening_hours: null,
   doctors: [],
@@ -143,6 +145,7 @@ export default function AdminHospitalProfiles() {
       hospital_id: h.hospital_id ?? null,
       thumbnail_url: h.thumbnail_url ?? "",
       keywords: h.keywords ?? [],
+      treatment_categories: h.treatment_categories ?? [],
       treatment_items: h.treatment_items ?? [],
       opening_hours: h.opening_hours ?? null,
       tagline: h.tagline ?? "",
@@ -237,6 +240,14 @@ export default function AdminHospitalProfiles() {
                       <input value={form.address} onChange={set("address")} style={inp} />
                     </Field>
                   </div>
+                  <Field label="진료하는 치료 (치료탭 검색 기준)">
+                    <TreatmentCategoryPicker
+                      value={form.treatment_categories ?? []}
+                      onChange={(treatment_categories) =>
+                        setForm((f) => ({ ...f, treatment_categories }))
+                      }
+                    />
+                  </Field>
                   <Field label="예약 링크 (선택)">
                     <input value={form.booking_url ?? ""} onChange={set("booking_url")} style={inp} placeholder="https://" />
                   </Field>
@@ -288,7 +299,7 @@ export default function AdminHospitalProfiles() {
             },
             {
               key: "treatments",
-              label: "치료항목",
+              label: "이벤트",
               content: (
                 <TreatmentItemsEditor
                   value={form.treatment_items ?? []}

--- a/src/routes/partner/PartnerProfile.tsx
+++ b/src/routes/partner/PartnerProfile.tsx
@@ -15,8 +15,10 @@ import { UserContext } from "../../App";
 import {
   KeywordsEditor,
   OpeningHoursEditor,
+  TreatmentCategoryPicker,
   TreatmentItemsEditor,
 } from "../../components/hospitalCardEditors";
+import { ProfilePreview } from "../../components/ProfilePreview";
 import { BannerImagesEditor, DetailBlocksEditor } from "../../components/HospitalContentEditors";
 import { FormTabs } from "../../components/FormTabs";
 import { PlacePicker } from "../../components/PlacePicker";
@@ -33,6 +35,7 @@ const EMPTY: PartnerProfileInput = {
   address: "",
   thumbnail_url: "",
   keywords: [],
+  treatment_categories: [],
   treatment_items: [],
   opening_hours: null,
   doctors: [],
@@ -59,6 +62,7 @@ export default function PartnerProfile() {
   const api = hasPartnerToken ? partnerApi : hospitalApi;
   const [me, setMe] = useState<PartnerMe | null>(null);
   const [form, setForm] = useState<PartnerProfileInput>(EMPTY);
+  const [previewing, setPreviewing] = useState(false);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [msg, setMsg] = useState<string | null>(null);
@@ -86,6 +90,7 @@ export default function PartnerProfile() {
             address: p.address ?? "",
             thumbnail_url: p.thumbnail_url ?? "",
             keywords: p.keywords ?? [],
+            treatment_categories: p.treatment_categories ?? [],
             treatment_items: p.treatment_items ?? [],
             opening_hours: p.opening_hours ?? null,
             tagline: p.tagline ?? "",
@@ -248,6 +253,14 @@ export default function PartnerProfile() {
                       <input value={form.address} onChange={set("address")} style={inp} />
                     </Field>
                   </div>
+                  <Field label="진료하는 치료 (치료탭 검색 기준)">
+                    <TreatmentCategoryPicker
+                      value={form.treatment_categories ?? []}
+                      onChange={(treatment_categories) =>
+                        setForm((s) => ({ ...s, treatment_categories }))
+                      }
+                    />
+                  </Field>
                   <Field label="예약 링크 (선택)">
                     <input value={form.booking_url ?? ""} onChange={set("booking_url")} style={inp} placeholder="https://" />
                   </Field>
@@ -299,12 +312,19 @@ export default function PartnerProfile() {
             },
             {
               key: "treatments",
-              label: "치료항목",
+              label: "이벤트",
               content: (
-                <TreatmentItemsEditor
-                  value={form.treatment_items ?? []}
-                  onChange={(treatment_items) => setForm((s) => ({ ...s, treatment_items }))}
-                />
+                <>
+                  <p style={{ margin: "0 0 12px", fontSize: 13, color: "#6b7280" }}>
+                    가격·프로모션을 올리는 곳입니다. 검색에 걸리는 조건은
+                    <b> 기본 정보 탭의 "진료하는 치료"</b>이고, 여기 내용은 상세 화면에만
+                    나옵니다.
+                  </p>
+                  <TreatmentItemsEditor
+                    value={form.treatment_items ?? []}
+                    onChange={(treatment_items) => setForm((s) => ({ ...s, treatment_items }))}
+                  />
+                </>
               ),
             },
             {
@@ -331,10 +351,19 @@ export default function PartnerProfile() {
         모든 탭의 내용이 저장 버튼 한 번으로 함께 저장됩니다. 소식은 등록·수정할 때 바로
         반영됩니다.
       </p>
-        <button style={{ ...saveBtn, opacity: canSave && !saving ? 1 : 0.5 }} disabled={!canSave || saving} onClick={save}>
-          {saving ? "저장 중…" : "저장"}
-        </button>
+        <div style={{ display: "flex", gap: 8 }}>
+          <button type="button" style={previewBtn} onClick={() => setPreviewing(true)}>
+            미리보기
+          </button>
+          <button style={{ ...saveBtn, opacity: canSave && !saving ? 1 : 0.5 }} disabled={!canSave || saving} onClick={save}>
+            {saving ? "저장 중…" : "저장"}
+          </button>
+        </div>
       </div>
+
+      {previewing && (
+        <ProfilePreview data={form} onClose={() => setPreviewing(false)} />
+      )}
     </div>
   );
 }
@@ -372,6 +401,13 @@ const saveBtn: CSSProperties = {
   fontSize: 15,
   fontWeight: 700,
   cursor: "pointer",
+};
+
+const previewBtn: CSSProperties = {
+  ...saveBtn,
+  background: "#fff",
+  color: "#0d47a1",
+  border: "1px solid #0d47a1",
 };
 
 const inp: CSSProperties = { width: "100%", padding: 8, border: "1px solid #ccc", borderRadius: 6, boxSizing: "border-box" };


### PR DESCRIPTION
백엔드 PR 과 함께 배포합니다. 백엔드 먼저 나가야 합니다.

- **진료하는 치료**를 기본 정보에서 고릅니다. 치료탭 검색 기준이라 가격표를 올릴 생각이 없는 병원도 반드시 지나가는 자리에 뒀습니다. 하나도 안 고르면 그 자리에서 경고합니다
- **치료항목 탭 → 이벤트** 가격·프로모션 자리로 뜻이 좁아졌고, 검색과 무관해져 카테고리를 비울 수 있습니다
- **미리보기 버튼** 폼 상태를 그대로 그립니다. 마이오닥 웹 상세를 새 탭으로 여는 방식은 저장한 내용만 보이고 승인 전 프로필은 404 라, 파트너가 미리보기를 누르는 시점에 둘 다 걸립니다

관리자 화면에도 같은 항목을 넣었습니다. 없으면 운영자가 등록한 병원이 검색에 안 잡힙니다.